### PR TITLE
feat(lib): added input for mat-select-country value

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Other modules in your application like for lazy loading import ` MatSelectCountr
 | option | bind  |  type  |   default    | description  |
 |:-------------------|:--------:|:------:|:------------:|:-------------------------------------------------------------------------------------------------|    
 | appearance      | `Input()`  | `MatFormFieldAppearance`    | - |  Possible appearance styles for `mat-form-field` | 'legacy' | 'standard' | 'fill' | 'outline'
+| country      | `Input()`  | `string`    | - |  Value to be set to the input (possible values are `Country` interface properties, case-insensitive)
 | label      | `Input()`  | `boolean`    | - |  `mat-form-field` label's text
 | placeHolder      | `Input()`  | `boolean`    | - |  input placeholder text
 | disabled      | `Input()`  | `boolean`    | - |  Whether the component is disabled

--- a/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.spec.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.spec.ts
@@ -6,6 +6,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import { SimpleChange } from '@angular/core';
 
 describe('SelectCountryComponent', () => {
   let component: MatSelectCountryComponent;
@@ -84,6 +85,31 @@ describe('SelectCountryComponent', () => {
       alpha3Code: 'DEU',
       numericCode: '276'
     });
+  });
+
+  it('should set correct value', async () => {
+
+    component.ngOnChanges({
+      country: new SimpleChange(undefined, 'de', true)
+    });
+
+    await fixture.whenStable();
+
+    expect(inputElement.value).toMatch('Germany');
+  });
+
+  it('should set empty value', async () => {
+
+    component.ngOnChanges({
+      country: new SimpleChange(undefined, 'de', true)
+    });
+    component.ngOnChanges({
+      country: new SimpleChange('de', undefined, false)
+    });
+
+    await fixture.whenStable();
+
+    expect(inputElement.value).toMatch('');
   });
 });
 

--- a/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.ts
@@ -1,4 +1,12 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges
+} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {COUNTRIES_DB} from './db';
 import {Observable} from 'rxjs';
@@ -26,9 +34,10 @@ export interface Country {
   templateUrl: 'mat-select-country.component.html',
   styleUrls: ['mat-select-country.component.scss']
 })
-export class MatSelectCountryComponent implements OnInit {
+export class MatSelectCountryComponent implements OnInit, OnChanges {
 
   @Input() appearance: MatFormFieldAppearance;
+  @Input() country: string;
   @Input() label: string;
   @Input() placeHolder = 'Select country';
   @Input() disabled: boolean;
@@ -48,6 +57,26 @@ export class MatSelectCountryComponent implements OnInit {
         debounceTime(300),
         map(value => this._filter(value))
       );
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.country) {
+      if (changes.country.currentValue) {
+        const newValue = changes.country.currentValue.toUpperCase();
+        this.selectedCountry = this.countries.find(country =>
+          country.name.toUpperCase() === newValue
+          || country.alpha2Code === newValue
+          || country.alpha3Code === newValue
+          || country.numericCode === newValue
+        );
+        this.countryFormControl.setValue(
+          this.selectedCountry ? this.selectedCountry.name : ''
+        );
+      } else {
+        this.selectedCountry = undefined;
+        this.countryFormControl.setValue('');
+      }
+    }
   }
 
   private _filter(value: string): Country[] {


### PR DESCRIPTION
At the moment, `mat-select-country` doesn't support populating from the parent component. However, there are cases when the library should be used not only to select a country, but also to display some default value.

In this PR a `country` property is added, which can be filled with any valid property of the `Country` interface (`name`, `alpha2Code`, `alpha3Code` or `numericCode`).