### PR TITLE
feat(lib): reset input value on blur

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Other modules in your application like for lazy loading import ` MatSelectCountr
 | label      | `Input()`  | `boolean`    | - |  `mat-form-field` label's text
 | placeHolder      | `Input()`  | `boolean`    | - |  input placeholder text
 | disabled      | `Input()`  | `boolean`    | - |  Whether the component is disabled
+| nullable      | `Input()`  | `boolean`    | - |  Whether the component is able to emit `null`
 | readonly      | `Input()`  | `boolean`    | - |  Whether the component is read only
 | onCountrySelected  | `Output()` | `EventEmitter<Country>`    | - | emits the selected country as object (see the interface below)
 

--- a/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.html
+++ b/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.html
@@ -5,7 +5,8 @@
               [svgIcon]="selectedCountry?.alpha2Code.toLowerCase()"></mat-icon>
     <input type="text" [placeholder]="placeHolder" aria-label="country"
            matInput [formControl]="countryFormControl"
-           [matAutocomplete]="auto" [readonly]="readonly" [disabled]="disabled">
+           [matAutocomplete]="auto" [readonly]="readonly" [disabled]="disabled"
+           (blur)="onBlur()">
     <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onOptionsSelected($event)">
       <mat-option *ngFor="let country of filteredOptions | async" [value]="country?.name">
         <mat-icon [svgIcon]="country?.alpha2Code.toLowerCase()"></mat-icon>

--- a/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.spec.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.spec.ts
@@ -111,6 +111,41 @@ describe('SelectCountryComponent', () => {
 
     expect(inputElement.value).toMatch('');
   });
+
+  it('should rollback input', async () => {
+
+    component.ngOnChanges({
+      country: new SimpleChange(undefined, 'de', true)
+    });
+
+    await fixture.whenStable();
+
+    inputElement.value = 'test';
+    inputElement.dispatchEvent(new Event('input'));
+    inputElement.dispatchEvent(new Event('blur'));
+
+    await fixture.whenStable();
+
+    expect(inputElement.value).toMatch('Germany');
+  });
+
+  it('should reset value', async () => {
+
+    component.nullable = true;
+    component.ngOnChanges({
+      country: new SimpleChange(undefined, 'de', true)
+    });
+
+    await fixture.whenStable();
+
+    inputElement.value = '';
+    inputElement.dispatchEvent(new Event('input'));
+    inputElement.dispatchEvent(new Event('blur'));
+
+    await fixture.whenStable();
+
+    expect(component.selectedCountry).toBeNull();
+  });
 });
 
 function prepare(inputElement: HTMLInputElement, value: string) {

--- a/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.ts
@@ -41,6 +41,7 @@ export class MatSelectCountryComponent implements OnInit, OnChanges {
   @Input() label: string;
   @Input() placeHolder = 'Select country';
   @Input() disabled: boolean;
+  @Input() nullable: boolean;
   @Input() readonly: boolean;
 
   @Output() onCountrySelected: EventEmitter<Country> = new EventEmitter<Country>();
@@ -89,6 +90,16 @@ export class MatSelectCountryComponent implements OnInit, OnChanges {
     );
   }
 
+  onBlur() {
+    if (this.countryFormControl.value || !this.nullable) {
+      this.countryFormControl.setValue(
+        this.selectedCountry ? this.selectedCountry.name : ''
+      );
+    } else if (this.selectedCountry) {
+      this.selectedCountry = null;
+      this.onCountrySelected.emit(null);
+    }
+  }
 
   onOptionsSelected($event: MatAutocompleteSelectedEvent) {
     this.selectedCountry = this.countries.find(country => country.name === $event.option.value);


### PR DESCRIPTION
This PR provides logic of tracking the `selectedCountry` property by the autocomplete input. This becomes helpful when the user modifies the input after selecting a country from the drop-down list. Without this kind of tracking, unfocusing the input will cause the _flag_ of country A to be displayed with the _name_ of country B.

The ability to clear the input with emitting of `null` is also included in this PR. A `nullable` input has been added so that it is possible to set whether the value can be cleared or not.

#### Examples

Here's how `mat-select-country` works now:

![d8bb04f1-c80d-448b-bdfb-6bc10169b3f5](https://user-images.githubusercontent.com/28267443/82122295-6d6ff400-979b-11ea-847c-f0ce718b0be1.gif)


And here are the proposed changes:

![b0fa6f01-8f34-4b64-b651-d8bb20e88308](https://user-images.githubusercontent.com/28267443/82122291-63e68c00-979b-11ea-9ab0-88de4c0e1699.gif)

