### PR TITLE
Partial load items

### DIFF
--- a/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.html
+++ b/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.html
@@ -5,10 +5,10 @@
               [svgIcon]="selectedCountry?.alpha2Code.toLowerCase()"></mat-icon>
     <input type="text" [placeholder]="placeHolder" aria-label="country"
            matInput [formControl]="countryFormControl"
-           [matAutocomplete]="auto" [readonly]="readonly" [disabled]="disabled"
-           (blur)="onBlur()">
-    <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onOptionsSelected($event)">
-      <mat-option *ngFor="let country of filteredOptions | async" [value]="country?.name">
+           [matAutocomplete]="countryAutocomplete" [readonly]="readonly" [disabled]="disabled"
+           (blur)="onBlur()" (input)="inputChanged($event.target.value)">
+    <mat-autocomplete #countryAutocomplete="matAutocomplete" (opened)="autocompleteScroll()" (optionSelected)="onOptionsSelected($event)">
+      <mat-option *ngFor="let country of filteredOptions" [value]="country?.name">
         <mat-icon [svgIcon]="country?.alpha2Code.toLowerCase()"></mat-icon>
         <small>{{country?.name}} - {{country?.alpha3Code}}</small>
       </mat-option>

--- a/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.ts
@@ -3,16 +3,18 @@ import {
   EventEmitter,
   Input,
   OnChanges,
+  OnDestroy,
   OnInit,
   Output,
-  SimpleChanges
+  SimpleChanges,
+  ViewChild
 } from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {COUNTRIES_DB} from './db';
-import {Observable} from 'rxjs';
-import {debounceTime, map, startWith} from 'rxjs/operators';
-import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
-import { MatFormFieldAppearance } from '@angular/material/form-field';
+import {fromEvent, Subject, Subscription} from 'rxjs';
+import {debounceTime, startWith, takeUntil} from 'rxjs/operators';
+import {MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger} from '@angular/material/autocomplete';
+import {MatFormFieldAppearance} from '@angular/material/form-field';
 
 /**
  * Country interface ISO 3166
@@ -34,7 +36,7 @@ export interface Country {
   templateUrl: 'mat-select-country.component.html',
   styleUrls: ['mat-select-country.component.scss']
 })
-export class MatSelectCountryComponent implements OnInit, OnChanges {
+export class MatSelectCountryComponent implements OnInit, OnChanges, OnDestroy {
 
   @Input() appearance: MatFormFieldAppearance;
   @Input() country: string;
@@ -43,21 +45,33 @@ export class MatSelectCountryComponent implements OnInit, OnChanges {
   @Input() disabled: boolean;
   @Input() nullable: boolean;
   @Input() readonly: boolean;
+  @Input() itemsLoadSize: number;
+  @ViewChild('countryAutocomplete') statesAutocompleteRef: MatAutocomplete;
+  @ViewChild(MatAutocompleteTrigger) autocompleteTrigger: MatAutocompleteTrigger;
 
   @Output() onCountrySelected: EventEmitter<Country> = new EventEmitter<Country>();
 
   countryFormControl = new FormControl();
   selectedCountry: Country;
   countries: Country[] = COUNTRIES_DB;
-  filteredOptions: Observable<Country[]>;
+  filteredOptions: Country[];
+
+  private modelChanged: Subject<string> = new Subject<string>();
+  private subscription: Subscription;
+  debounceTime = 300;
+
+  filterString = '';
 
   ngOnInit() {
-    this.filteredOptions = this.countryFormControl.valueChanges
+    this.subscription = this.modelChanged
       .pipe(
         startWith(''),
-        debounceTime(300),
-        map(value => this._filter(value))
-      );
+        debounceTime(this.debounceTime),
+      )
+      .subscribe((value) => {
+        this.filterString = value;
+        this._filter(value);
+      });
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -80,14 +94,19 @@ export class MatSelectCountryComponent implements OnInit, OnChanges {
     }
   }
 
-  private _filter(value: string): Country[] {
+  private _filter(value: string) {
     const filterValue = value.toLowerCase();
 
-    return this.countries.filter((option: Country) =>
-      option.name.toLowerCase().includes(filterValue)
-      || option.alpha2Code.toLowerCase().includes(filterValue)
-      || option.alpha3Code.toLowerCase().includes(filterValue)
-    );
+    // if not filtered, fetch reduced array
+    if (this.itemsLoadSize && filterValue === '') {
+      this.filteredOptions = this.countries.slice(0, this.itemsLoadSize);
+    } else {
+      this.filteredOptions = this.countries.filter((option: Country) =>
+        option.name.toLowerCase().includes(filterValue)
+        || option.alpha2Code.toLowerCase().includes(filterValue)
+        || option.alpha3Code.toLowerCase().includes(filterValue)
+      );
+    }
   }
 
   onBlur() {
@@ -104,5 +123,48 @@ export class MatSelectCountryComponent implements OnInit, OnChanges {
   onOptionsSelected($event: MatAutocompleteSelectedEvent) {
     this.selectedCountry = this.countries.find(country => country.name === $event.option.value);
     this.onCountrySelected.emit(this.selectedCountry);
+  }
+
+  autocompleteScroll() {
+    if (this.itemsLoadSize) {
+      setTimeout(() => {
+        if (
+          this.statesAutocompleteRef &&
+          this.autocompleteTrigger &&
+          this.statesAutocompleteRef.panel
+        ) {
+          fromEvent(this.statesAutocompleteRef.panel.nativeElement, 'scroll')
+            .pipe(
+              takeUntil(this.autocompleteTrigger.panelClosingActions)
+            )
+            .subscribe(() => {
+              const scrollTop = this.statesAutocompleteRef.panel.nativeElement
+                .scrollTop;
+              const scrollHeight = this.statesAutocompleteRef.panel.nativeElement
+                .scrollHeight;
+              const elementHeight = this.statesAutocompleteRef.panel.nativeElement
+                .clientHeight;
+              const atBottom = scrollHeight === scrollTop + elementHeight;
+              if (atBottom) {
+                // fetch more data if not filtered
+                if (this.filterString === '') {
+                  const fromIndex = this.filteredOptions.length;
+                  const toIndex: number = +this.filteredOptions.length + +this.itemsLoadSize;
+                  this.filteredOptions = [...this.filteredOptions, ...this.countries.slice(fromIndex, toIndex)];
+                }
+              }
+            });
+        }
+      });
+    }
+
+  }
+
+  inputChanged(value: string): void {
+    this.modelChanged.next(value);
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
   }
 }


### PR DESCRIPTION
Due to slow load of items when component gains focus, i have added parameter **itemsLoadSize** that changes component behavior.
itemsLoadSize represents number of items loaded initially when component gets focus, and when scroll hits bottom. In that way we enable smooth component behavior.
If parameter is not set, component will load all items like it used to.