### PR TITLE
fix(lib): fixed value reset

### DIFF
--- a/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.spec.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.spec.ts
@@ -93,7 +93,7 @@ describe('SelectCountryComponent', () => {
       country: new SimpleChange(undefined, 'de', true)
     });
 
-    await fixture.whenStable();
+    fixture.detectChanges();
 
     expect(inputElement.value).toMatch('Germany');
   });

--- a/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/mat-select-country.component.ts
@@ -101,7 +101,7 @@ export class MatSelectCountryComponent implements OnInit, OnChanges, ControlValu
   }
 
   onBlur() {
-    if (this.value || !this.nullable) {
+    if (this.countryFormControl.value || !this.nullable) {
       this.countryFormControl.setValue(
         this.value ? this.value.name : ''
       );


### PR DESCRIPTION
The value reset (#9) was broken with ed727df, as here we still have to depend on the control value and not the internal component value. The general idea is to restore the value on blur if the input control is not empty or the component is not nullable.

Thanks @josepaiva94 for noticing this in #29