### PR TITLE
Update es.ts

### DIFF
--- a/projects/angular-material-extensions/select-country/src/lib/i18n/es.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/i18n/es.ts
@@ -487,7 +487,7 @@ export const COUNTRIES_DB_ES: Country[] =
     },
     {
       name: 'Islandia',
-      alpha2Code: 'ES',
+      alpha2Code: 'IS',
       alpha3Code: 'ISL',
       numericCode: '352'
     },


### PR DESCRIPTION
Iceland in spanish displays the Spanish flag.

This is probably due to the wrong `alpha2Code` for 'Islandia' 
![image](https://user-images.githubusercontent.com/6580134/102650257-e76dbe80-416a-11eb-86f9-7737390fb654.png)
