### PR TITLE
Fix for multiple alpha2Codes

### DIFF
--- a/projects/angular-material-extensions/select-country/src/lib/i18n/de.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/i18n/de.ts
@@ -1,1219 +1,1222 @@
-import {Country} from '../mat-select-country.component';
+import { Country } from '../mat-select-country.component';
 
-export const COUNTRIES_DB_DE: Country[] =
-  [
-    {
-      name: 'Afghanistan',
-      alpha2Code: 'AF',
-      alpha3Code: 'AFG',
-      numericCode: '004'
-    },
-    {
-      name: 'Albanien',
-      alpha2Code: 'AL',
-      alpha3Code: 'ALB',
-      numericCode: '008'
-    },
-    {
-      name: 'Algerien',
-      alpha2Code: 'DZ',
-      alpha3Code: 'DZA',
-      numericCode: '012'
-    },
-    {
-      name: 'Amerikanisch-Samoa',
-      alpha2Code: 'AS',
-      alpha3Code: 'ASM',
-      numericCode: '016'
-    },
-    {
-      name: 'Andorra',
-      alpha2Code: 'AD',
-      alpha3Code: 'AND',
-      numericCode: '020'
-    },
-    {
-      name: 'Angola',
-      alpha2Code: 'AO',
-      alpha3Code: 'AGO',
-      numericCode: '024'
-    },
-    {
-      name: 'Antigua und Barbuda',
-      alpha2Code: 'AG',
-      alpha3Code: 'ATG',
-      numericCode: '028'
-    },
-    {
-      name: 'Argentinien',
-      alpha2Code: 'AR',
-      alpha3Code: 'ARG',
-      numericCode: '032'
-    },
-    {
-      name: 'Armenien',
-      alpha2Code: 'AM',
-      alpha3Code: 'ARM',
-      numericCode: '051'
-    },
-    {
-      name: 'Australien',
-      alpha2Code: 'AU',
-      alpha3Code: 'AUS',
-      numericCode: '036'
-    },
-    {
-      name: 'Österreich',
-      alpha2Code: 'AT',
-      alpha3Code: 'AUT',
-      numericCode: '040'
-    },
-    {
-      name: 'Aserbaidschan',
-      alpha2Code: 'AZ',
-      alpha3Code: 'AZE',
-      numericCode: '031'
-    },
-    {
-      name: 'Bahamas',
-      alpha2Code: 'BS',
-      alpha3Code: 'BHS',
-      numericCode: '044'
-    },
-    {
-      name: 'Bahrain',
-      alpha2Code: 'BH',
-      alpha3Code: 'BHR',
-      numericCode: '048'
-    },
-    {
-      name: 'Bangladesch',
-      alpha2Code: 'BD',
-      alpha3Code: 'BGD',
-      numericCode: '050'
-    },
-    {
-      name: 'Barbados',
-      alpha2Code: 'BB',
-      alpha3Code: 'BRB',
-      numericCode: '052'
-    },
-    {
-      name: 'Weißrussland',
-      alpha2Code: 'BY',
-      alpha3Code: 'BLR',
-      numericCode: '112'
-    },
-    {
-      name: 'Belgien',
-      alpha2Code: 'BE',
-      alpha3Code: 'BEL',
-      numericCode: '056'
-    },
-    {
-      name: 'Belize',
-      alpha2Code: 'BZ',
-      alpha3Code: 'BLZ',
-      numericCode: '084'
-    },
-    {
-      name: 'Benin',
-      alpha2Code: 'BJ',
-      alpha3Code: 'BEN',
-      numericCode: '204'
-    },
-    {
-      name: 'Bermuda',
-      alpha2Code: 'BM',
-      alpha3Code: 'BMU',
-      numericCode: '060'
-    },
-    {
-      name: 'Bhutan',
-      alpha2Code: 'BT',
-      alpha3Code: 'BTN',
-      numericCode: '064'
-    },
-    {
-      name: 'Bolivien',
-      alpha2Code: 'BO',
-      alpha3Code: 'BOL',
-      numericCode: '068'
-    },
-    {
-      name: 'Bonaire, Sint Eustatius und Saba',
-      alpha2Code: 'BQ',
-      alpha3Code: 'BES',
-      numericCode: '535'
-    },
-    {
-      name: 'Bosnien und Herzegowina',
-      alpha2Code: 'BA',
-      alpha3Code: 'BIH',
-      numericCode: '070'
-    },
-    {
-      name: 'Botswana',
-      alpha2Code: 'BW',
-      alpha3Code: 'BWA',
-      numericCode: '072'
-    },
-    {
-      name: 'Bouvet Island',
-      alpha2Code: 'BV',
-      alpha3Code: 'BVT',
-      numericCode: '074'
-    },
-    {
-      name: 'Brasilien',
-      alpha2Code: 'BR',
-      alpha3Code: 'BRA',
-      numericCode: '076'
-    },
-    {
-      name: 'Brunei',
-      alpha2Code: 'BN',
-      alpha3Code: 'BRN',
-      numericCode: '096'
-    },
-    {
-      name: 'Bulgarien',
-      alpha2Code: 'BG',
-      alpha3Code: 'BGR',
-      numericCode: '100'
-    },
-    {
-      name: 'Burkina Faso',
-      alpha2Code: 'BF',
-      alpha3Code: 'BFA',
-      numericCode: '854'
-    },
-    {
-      name: 'Burundi',
-      alpha2Code: 'BI',
-      alpha3Code: 'BDI',
-      numericCode: '108'
-    },
-    {
-      name: 'Cabo Verde',
-      alpha2Code: 'CV',
-      alpha3Code: 'CPV',
-      numericCode: '132'
-    },
-    {
-      name: 'Kambodscha',
-      alpha2Code: 'KH',
-      alpha3Code: 'KHM',
-      numericCode: '116'
-    },
-    {
-      name: 'Kamerun',
-      alpha2Code: 'CM',
-      alpha3Code: 'CMR',
-      numericCode: '120'
-    },
-    {
-      name: 'Kanada',
-      alpha2Code: 'CA',
-      alpha3Code: 'CAN',
-      numericCode: '124'
-    },
-    {
-      name: 'Zentralafrikanische Republik',
-      alpha2Code: 'CF',
-      alpha3Code: 'CAF',
-      numericCode: '140'
-    },
-    {
-      name: 'Tschad',
-      alpha2Code: 'TD',
-      alpha3Code: 'TCD',
-      numericCode: '148'
-    },
-    {
-      name: 'Chile',
-      alpha2Code: 'CL',
-      alpha3Code: 'CHL',
-      numericCode: '152'
-    },
-    {
-      name: 'China',
-      alpha2Code: 'CN',
-      alpha3Code: 'CHN',
-      numericCode: '156'
-    },
-    {
-      name: 'Kolumbien',
-      alpha2Code: 'CO',
-      alpha3Code: 'COL',
-      numericCode: '170'
-    },
-    {
-      name: 'Kongo (Demokratische Republik)',
-      alpha2Code: 'CD',
-      alpha3Code: 'COD',
-      numericCode: '180'
-    },
-    {
-      name: 'Kongo (Republik)',
-      alpha2Code: 'CG',
-      alpha3Code: 'COG',
-      numericCode: '178'
-    },
-    {
-      name: 'Costa Rica',
-      alpha2Code: 'CR',
-      alpha3Code: 'CRI',
-      numericCode: '188'
-    }, {
+export const COUNTRIES_DB_DE: Country[] = [
+  {
+    name: 'Afghanistan',
+    alpha2Code: 'AF',
+    alpha3Code: 'AFG',
+    numericCode: '004'
+  },
+  {
+    name: 'Albanien',
+    alpha2Code: 'AL',
+    alpha3Code: 'ALB',
+    numericCode: '008'
+  },
+  {
+    name: 'Algerien',
+    alpha2Code: 'DZ',
+    alpha3Code: 'DZA',
+    numericCode: '012'
+  },
+  {
+    name: 'Amerikanisch-Samoa',
+    alpha2Code: 'AS',
+    alpha3Code: 'ASM',
+    numericCode: '016'
+  },
+  {
+    name: 'Andorra',
+    alpha2Code: 'AD',
+    alpha3Code: 'AND',
+    numericCode: '020'
+  },
+  {
+    name: 'Angola',
+    alpha2Code: 'AO',
+    alpha3Code: 'AGO',
+    numericCode: '024'
+  },
+  {
+    name: 'Antigua und Barbuda',
+    alpha2Code: 'AG',
+    alpha3Code: 'ATG',
+    numericCode: '028'
+  },
+  {
+    name: 'Argentinien',
+    alpha2Code: 'AR',
+    alpha3Code: 'ARG',
+    numericCode: '032'
+  },
+  {
+    name: 'Armenien',
+    alpha2Code: 'AM',
+    alpha3Code: 'ARM',
+    numericCode: '051'
+  },
+  {
+    name: 'Australien',
+    alpha2Code: 'AU',
+    alpha3Code: 'AUS',
+    numericCode: '036'
+  },
+  {
+    name: 'Österreich',
+    alpha2Code: 'AT',
+    alpha3Code: 'AUT',
+    numericCode: '040'
+  },
+  {
+    name: 'Aserbaidschan',
+    alpha2Code: 'AZ',
+    alpha3Code: 'AZE',
+    numericCode: '031'
+  },
+  {
+    name: 'Bahamas',
+    alpha2Code: 'BS',
+    alpha3Code: 'BHS',
+    numericCode: '044'
+  },
+  {
+    name: 'Bahrain',
+    alpha2Code: 'BH',
+    alpha3Code: 'BHR',
+    numericCode: '048'
+  },
+  {
+    name: 'Bangladesch',
+    alpha2Code: 'BD',
+    alpha3Code: 'BGD',
+    numericCode: '050'
+  },
+  {
+    name: 'Barbados',
+    alpha2Code: 'BB',
+    alpha3Code: 'BRB',
+    numericCode: '052'
+  },
+  {
+    name: 'Weißrussland',
+    alpha2Code: 'BY',
+    alpha3Code: 'BLR',
+    numericCode: '112'
+  },
+  {
+    name: 'Belgien',
+    alpha2Code: 'BE',
+    alpha3Code: 'BEL',
+    numericCode: '056'
+  },
+  {
+    name: 'Belize',
+    alpha2Code: 'BZ',
+    alpha3Code: 'BLZ',
+    numericCode: '084'
+  },
+  {
+    name: 'Benin',
+    alpha2Code: 'BJ',
+    alpha3Code: 'BEN',
+    numericCode: '204'
+  },
+  {
+    name: 'Bermuda',
+    alpha2Code: 'BM',
+    alpha3Code: 'BMU',
+    numericCode: '060'
+  },
+  {
+    name: 'Bhutan',
+    alpha2Code: 'BT',
+    alpha3Code: 'BTN',
+    numericCode: '064'
+  },
+  {
+    name: 'Bolivien',
+    alpha2Code: 'BO',
+    alpha3Code: 'BOL',
+    numericCode: '068'
+  },
+  {
+    name: 'Bonaire, Sint Eustatius und Saba',
+    alpha2Code: 'BQ',
+    alpha3Code: 'BES',
+    numericCode: '535'
+  },
+  {
+    name: 'Bosnien und Herzegowina',
+    alpha2Code: 'BA',
+    alpha3Code: 'BIH',
+    numericCode: '070'
+  },
+  {
+    name: 'Botswana',
+    alpha2Code: 'BW',
+    alpha3Code: 'BWA',
+    numericCode: '072'
+  },
+  {
+    name: 'Bouvet Island',
+    alpha2Code: 'BV',
+    alpha3Code: 'BVT',
+    numericCode: '074'
+  },
+  {
+    name: 'Brasilien',
+    alpha2Code: 'BR',
+    alpha3Code: 'BRA',
+    numericCode: '076'
+  },
+  {
+    name: 'Brunei',
+    alpha2Code: 'BN',
+    alpha3Code: 'BRN',
+    numericCode: '096'
+  },
+  {
+    name: 'Bulgarien',
+    alpha2Code: 'BG',
+    alpha3Code: 'BGR',
+    numericCode: '100'
+  },
+  {
+    name: 'Burkina Faso',
+    alpha2Code: 'BF',
+    alpha3Code: 'BFA',
+    numericCode: '854'
+  },
+  {
+    name: 'Burundi',
+    alpha2Code: 'BI',
+    alpha3Code: 'BDI',
+    numericCode: '108'
+  },
+  {
+    name: 'Cabo Verde',
+    alpha2Code: 'CV',
+    alpha3Code: 'CPV',
+    numericCode: '132'
+  },
+  {
+    name: 'Kambodscha',
+    alpha2Code: 'KH',
+    alpha3Code: 'KHM',
+    numericCode: '116'
+  },
+  {
+    name: 'Kamerun',
+    alpha2Code: 'CM',
+    alpha3Code: 'CMR',
+    numericCode: '120'
+  },
+  {
+    name: 'Kanada',
+    alpha2Code: 'CA',
+    alpha3Code: 'CAN',
+    numericCode: '124'
+  },
+  {
+    name: 'Zentralafrikanische Republik',
+    alpha2Code: 'CF',
+    alpha3Code: 'CAF',
+    numericCode: '140'
+  },
+  {
+    name: 'Tschad',
+    alpha2Code: 'TD',
+    alpha3Code: 'TCD',
+    numericCode: '148'
+  },
+  {
+    name: 'Chile',
+    alpha2Code: 'CL',
+    alpha3Code: 'CHL',
+    numericCode: '152'
+  },
+  {
+    name: 'China',
+    alpha2Code: 'CN',
+    alpha3Code: 'CHN',
+    numericCode: '156'
+  },
+  {
+    name: 'Kolumbien',
+    alpha2Code: 'CO',
+    alpha3Code: 'COL',
+    numericCode: '170'
+  },
+  {
+    name: 'Kongo (Demokratische Republik)',
+    alpha2Code: 'CD',
+    alpha3Code: 'COD',
+    numericCode: '180'
+  },
+  {
+    name: 'Kongo (Republik)',
+    alpha2Code: 'CG',
+    alpha3Code: 'COG',
+    numericCode: '178'
+  },
+  {
+    name: 'Costa Rica',
+    alpha2Code: 'CR',
+    alpha3Code: 'CRI',
+    numericCode: '188'
+  },
+  {
     name: 'Kroatien',
     alpha2Code: 'HR',
     alpha3Code: 'HRV',
     numericCode: '191'
   },
-    {
-      name: 'Kuba',
-      alpha2Code: 'CU',
-      alpha3Code: 'CUB',
-      numericCode: '192'
-    },
-    {
-      name: 'Zypern',
-      alpha2Code: 'CY',
-      alpha3Code: 'CYP',
-      numericCode: '196'
-    },
-    {
-      name: 'Tschechien',
-      alpha2Code: 'CZ',
-      alpha3Code: 'CZE',
-      numericCode: '203'
-    },
-    {
-      name: 'Côte d \' Ivoire ',
-      alpha2Code: 'CI',
-      alpha3Code: 'CIV',
-      numericCode: '384'
-    },
-    {
-      name: 'Dänemark',
-      alpha2Code: 'DK',
-      alpha3Code: 'DNK',
-      numericCode: '208'
-    },
-    {
-      name: 'Dschibuti',
-      alpha2Code: 'DJ',
-      alpha3Code: 'DJI',
-      numericCode: '262'
-    },
-    {
-      name: 'Dominica',
-      alpha2Code: 'DM',
-      alpha3Code: 'DMA',
-      numericCode: '212'
-    },
-    {
-      name: 'Dominikanische Republik',
-      alpha2Code: 'DO',
-      alpha3Code: 'DOM',
-      numericCode: '214'
-    },
-    {
-      name: 'Ecuador',
-      alpha2Code: 'EC',
-      alpha3Code: 'ECU',
-      numericCode: '218'
-    },
-    {
-      name: 'Ägypten',
-      alpha2Code: 'EG',
-      alpha3Code: 'EGY',
-      numericCode: '818'
-    },
-    {
-      name: 'El Salvador',
-      alpha2Code: 'SV',
-      alpha3Code: 'SLV',
-      numericCode: '222'
-    },
-    {
-      name: 'Äquatorialguinea',
-      alpha2Code: 'GQ',
-      alpha3Code: 'GNQ',
-      numericCode: '226'
-    },
-    {
-      name: 'Eritrea',
-      alpha2Code: 'ER',
-      alpha3Code: 'ERI',
-      numericCode: '232'
-    },
-    {
-      name: 'Estland',
-      alpha2Code: 'EE',
-      alpha3Code: 'EST',
-      numericCode: '233'
-    },
-    {
-      name: 'Eswatini',
-      alpha2Code: 'SZ',
-      alpha3Code: 'SWZ',
-      numericCode: '748'
-    },
-    {
-      name: 'Äthiopien',
-      alpha2Code: 'ET',
-      alpha3Code: 'ETH',
-      numericCode: '231'
-    },
-    {
-      name: 'Fidschi',
-      alpha2Code: 'FJ',
-      alpha3Code: 'FJI',
-      numericCode: '242'
-    },
-    {
-      name: 'Finnland',
-      alpha2Code: 'FI',
-      alpha3Code: 'FIN',
-      numericCode: '246'
-    },
-    {
-      name: 'Frankreich',
-      alpha2Code: 'FR',
-      alpha3Code: 'FRA',
-      numericCode: '250'
-    },
-    {
-      name: 'Gabun',
-      alpha2Code: 'GA',
-      alpha3Code: 'GAB',
-      numericCode: '266'
-    },
-    {
-      name: 'Gambia',
-      alpha2Code: 'GM',
-      alpha3Code: 'GMB',
-      numericCode: '270'
-    },
-    {
-      name: 'Georgia',
-      alpha2Code: 'GE',
-      alpha3Code: 'GEO',
-      numericCode: '268'
-    },
-    {
-      name: 'Deutschland',
-      alpha2Code: 'DE',
-      alpha3Code: 'DEU',
-      numericCode: '276'
-    },
-    {
-      name: 'Ghana',
-      alpha2Code: 'GH',
-      alpha3Code: 'GHA',
-      numericCode: '288'
-    },
-    {
-      name: 'Griechenland',
-      alpha2Code: 'GR',
-      alpha3Code: 'GRC',
-      numericCode: '300'
-    },
-    {
-      name: 'Grönland',
-      alpha2Code: 'GL',
-      alpha3Code: 'GRL',
-      numericCode: '304'
-    },
-    {
-      name: 'Guadeloupe',
-      alpha2Code: 'GP',
-      alpha3Code: 'GLP',
-      numericCode: '312'
-    },
-    {
-      name: 'Grenada',
-      alpha2Code: 'GD',
-      alpha3Code: 'GRD',
-      numericCode: '308'
-    },
-    {
-      name: 'Guatemala',
-      alpha2Code: 'GT',
-      alpha3Code: 'GTM',
-      numericCode: '320'
-    },
-    {
-      name: 'Guinea',
-      alpha2Code: 'GN',
-      alpha3Code: 'GIN',
-      numericCode: '324'
-    },
-    {
-      name: 'Guinea-Bissau',
-      alpha2Code: 'GW',
-      alpha3Code: 'GNB',
-      numericCode: '624'
-    },
-    {
-      name: 'Guyana',
-      alpha2Code: 'GY',
-      alpha3Code: 'GUY',
-      numericCode: '328'
-    }, {
+  {
+    name: 'Kuba',
+    alpha2Code: 'CU',
+    alpha3Code: 'CUB',
+    numericCode: '192'
+  },
+  {
+    name: 'Zypern',
+    alpha2Code: 'CY',
+    alpha3Code: 'CYP',
+    numericCode: '196'
+  },
+  {
+    name: 'Tschechien',
+    alpha2Code: 'CZ',
+    alpha3Code: 'CZE',
+    numericCode: '203'
+  },
+  {
+    name: "Côte d ' Ivoire ",
+    alpha2Code: 'CI',
+    alpha3Code: 'CIV',
+    numericCode: '384'
+  },
+  {
+    name: 'Dänemark',
+    alpha2Code: 'DK',
+    alpha3Code: 'DNK',
+    numericCode: '208'
+  },
+  {
+    name: 'Dschibuti',
+    alpha2Code: 'DJ',
+    alpha3Code: 'DJI',
+    numericCode: '262'
+  },
+  {
+    name: 'Dominica',
+    alpha2Code: 'DM',
+    alpha3Code: 'DMA',
+    numericCode: '212'
+  },
+  {
+    name: 'Dominikanische Republik',
+    alpha2Code: 'DO',
+    alpha3Code: 'DOM',
+    numericCode: '214'
+  },
+  {
+    name: 'Ecuador',
+    alpha2Code: 'EC',
+    alpha3Code: 'ECU',
+    numericCode: '218'
+  },
+  {
+    name: 'Ägypten',
+    alpha2Code: 'EG',
+    alpha3Code: 'EGY',
+    numericCode: '818'
+  },
+  {
+    name: 'El Salvador',
+    alpha2Code: 'SV',
+    alpha3Code: 'SLV',
+    numericCode: '222'
+  },
+  {
+    name: 'Äquatorialguinea',
+    alpha2Code: 'GQ',
+    alpha3Code: 'GNQ',
+    numericCode: '226'
+  },
+  {
+    name: 'Eritrea',
+    alpha2Code: 'ER',
+    alpha3Code: 'ERI',
+    numericCode: '232'
+  },
+  {
+    name: 'Estland',
+    alpha2Code: 'EE',
+    alpha3Code: 'EST',
+    numericCode: '233'
+  },
+  {
+    name: 'Eswatini',
+    alpha2Code: 'SZ',
+    alpha3Code: 'SWZ',
+    numericCode: '748'
+  },
+  {
+    name: 'Äthiopien',
+    alpha2Code: 'ET',
+    alpha3Code: 'ETH',
+    numericCode: '231'
+  },
+  {
+    name: 'Fidschi',
+    alpha2Code: 'FJ',
+    alpha3Code: 'FJI',
+    numericCode: '242'
+  },
+  {
+    name: 'Finnland',
+    alpha2Code: 'FI',
+    alpha3Code: 'FIN',
+    numericCode: '246'
+  },
+  {
+    name: 'Frankreich',
+    alpha2Code: 'FR',
+    alpha3Code: 'FRA',
+    numericCode: '250'
+  },
+  {
+    name: 'Gabun',
+    alpha2Code: 'GA',
+    alpha3Code: 'GAB',
+    numericCode: '266'
+  },
+  {
+    name: 'Gambia',
+    alpha2Code: 'GM',
+    alpha3Code: 'GMB',
+    numericCode: '270'
+  },
+  {
+    name: 'Georgia',
+    alpha2Code: 'GE',
+    alpha3Code: 'GEO',
+    numericCode: '268'
+  },
+  {
+    name: 'Deutschland',
+    alpha2Code: 'DE',
+    alpha3Code: 'DEU',
+    numericCode: '276'
+  },
+  {
+    name: 'Ghana',
+    alpha2Code: 'GH',
+    alpha3Code: 'GHA',
+    numericCode: '288'
+  },
+  {
+    name: 'Griechenland',
+    alpha2Code: 'GR',
+    alpha3Code: 'GRC',
+    numericCode: '300'
+  },
+  {
+    name: 'Grönland',
+    alpha2Code: 'GL',
+    alpha3Code: 'GRL',
+    numericCode: '304'
+  },
+  {
+    name: 'Guadeloupe',
+    alpha2Code: 'GP',
+    alpha3Code: 'GLP',
+    numericCode: '312'
+  },
+  {
+    name: 'Grenada',
+    alpha2Code: 'GD',
+    alpha3Code: 'GRD',
+    numericCode: '308'
+  },
+  {
+    name: 'Guatemala',
+    alpha2Code: 'GT',
+    alpha3Code: 'GTM',
+    numericCode: '320'
+  },
+  {
+    name: 'Guinea',
+    alpha2Code: 'GN',
+    alpha3Code: 'GIN',
+    numericCode: '324'
+  },
+  {
+    name: 'Guinea-Bissau',
+    alpha2Code: 'GW',
+    alpha3Code: 'GNB',
+    numericCode: '624'
+  },
+  {
+    name: 'Guyana',
+    alpha2Code: 'GY',
+    alpha3Code: 'GUY',
+    numericCode: '328'
+  },
+  {
     name: 'Haiti',
     alpha2Code: 'HT',
     alpha3Code: 'HTI',
     numericCode: '332'
   },
-    {
-      name: 'Honduras',
-      alpha2Code: 'HN',
-      alpha3Code: 'HND',
-      numericCode: '340'
-    },
-    {
-      name: 'Hong Kong',
-      alpha2Code: 'HK',
-      alpha3Code: 'HKG',
-      numericCode: '344'
-    },
-    {
-      name: 'Ungarn',
-      alpha2Code: 'HU',
-      alpha3Code: 'HUN',
-      numericCode: '348'
-    },
-    {
-      name: 'Island',
-      alpha2Code: 'IS',
-      alpha3Code: 'ISL',
-      numericCode: '352'
-    },
-    {
-      name: 'Indien',
-      alpha2Code: 'IN',
-      alpha3Code: 'IND',
-      numericCode: '356'
-    },
-    {
-      name: 'Indonesien',
-      alpha2Code: 'ID',
-      alpha3Code: 'IDN',
-      numericCode: '360'
-    },
-    {
-      name: 'Iran',
-      alpha2Code: 'IR',
-      alpha3Code: 'IRN',
-      numericCode: '364'
-    },
-    {
-      name: 'Irak',
-      alpha2Code: 'IQ',
-      alpha3Code: 'IRQ',
-      numericCode: '368'
-    },
-    {
-      name: 'Irland',
-      alpha2Code: 'IE',
-      alpha3Code: 'IRL',
-      numericCode: '372'
-    },
-    {
-      name: 'Israel',
-      alpha2Code: 'IL',
-      alpha3Code: 'ISR',
-      numericCode: '376'
-    },
-    {
-      name: 'Italien',
-      alpha2Code: 'IT',
-      alpha3Code: 'ITA',
-      numericCode: '380'
-    },
-    {
-      name: 'Jamaika',
-      alpha2Code: 'JM',
-      alpha3Code: 'JAM',
-      numericCode: '388'
-    },
-    {
-      name: 'Japan',
-      alpha2Code: 'JP',
-      alpha3Code: 'JPN',
-      numericCode: '392'
-    },
-    {
-      name: 'Jersey',
-      alpha2Code: 'JE',
-      alpha3Code: 'JEY',
-      numericCode: '832'
-    },
-    {
-      name: 'Jordan',
-      alpha2Code: 'JO',
-      alpha3Code: 'JOR',
-      numericCode: '400'
-    },
-    {
-      name: 'Kasachstan',
-      alpha2Code: 'KZ',
-      alpha3Code: 'KAZ',
-      numericCode: '398'
-    },
-    {
-      name: 'Kenia',
-      alpha2Code: 'KE',
-      alpha3Code: 'KEN',
-      numericCode: '404'
-    },
-    {
-      name: 'Kiribati',
-      alpha2Code: 'KI',
-      alpha3Code: 'KIR',
-      numericCode: '296'
-    },
-    {
-      name: 'Korea (Demokratische Volksrepublik)',
-      alpha2Code: 'KP',
-      alpha3Code: 'PRK',
-      numericCode: '408'
-    },
-    {
-      name: 'Korea (Republik) \ t',
-      alpha2Code: 'KR',
-      alpha3Code: 'KOR',
-      numericCode: '410'
-    },
-    {
-      name: 'Kuwait',
-      alpha2Code: 'KW',
-      alpha3Code: 'KWT',
-      numericCode: '414'
-    },
-    {
-      name: 'Kirgisistan',
-      alpha2Code: 'KG',
-      alpha3Code: 'KGZ',
-      numericCode: '417'
-    },
-    {
-      name: 'Laos',
-      alpha2Code: 'LA',
-      alpha3Code: 'LAO',
-      numericCode: '418'
-    },
-    {
-      name: 'Lettland',
-      alpha2Code: 'LV',
-      alpha3Code: 'LVA',
-      numericCode: '428'
-    },
-    {
-      name: 'Libanon',
-      alpha2Code: 'LB',
-      alpha3Code: 'LBN',
-      numericCode: '422'
-    },
-    {
-      name: 'Lesotho',
-      alpha2Code: 'LS',
-      alpha3Code: 'LSO',
-      numericCode: '426'
-    },
-    {
-      name: 'Liberia',
-      alpha2Code: 'LR',
-      alpha3Code: 'LBR',
-      numericCode: '430'
-    },
-    {
-      name: 'Libyen',
-      alpha2Code: 'LY',
-      alpha3Code: 'LBY',
-      numericCode: '434'
-    },
-    {
-      name: 'Liechtenstein',
-      alpha2Code: 'LI',
-      alpha3Code: 'LIE',
-      numericCode: '438'
-    },
-    {
-      name: 'Litauen',
-      alpha2Code: 'LT',
-      alpha3Code: 'LTU',
-      numericCode: '440'
-    },
-    {
-      name: 'Luxemburg',
-      alpha2Code: 'LU',
-      alpha3Code: 'LUX',
-      numericCode: '442'
-    }, {
+  {
+    name: 'Honduras',
+    alpha2Code: 'HN',
+    alpha3Code: 'HND',
+    numericCode: '340'
+  },
+  {
+    name: 'Hong Kong',
+    alpha2Code: 'HK',
+    alpha3Code: 'HKG',
+    numericCode: '344'
+  },
+  {
+    name: 'Ungarn',
+    alpha2Code: 'HU',
+    alpha3Code: 'HUN',
+    numericCode: '348'
+  },
+  {
+    name: 'Island',
+    alpha2Code: 'IS',
+    alpha3Code: 'ISL',
+    numericCode: '352'
+  },
+  {
+    name: 'Indien',
+    alpha2Code: 'IN',
+    alpha3Code: 'IND',
+    numericCode: '356'
+  },
+  {
+    name: 'Indonesien',
+    alpha2Code: 'ID',
+    alpha3Code: 'IDN',
+    numericCode: '360'
+  },
+  {
+    name: 'Iran',
+    alpha2Code: 'IR',
+    alpha3Code: 'IRN',
+    numericCode: '364'
+  },
+  {
+    name: 'Irak',
+    alpha2Code: 'IQ',
+    alpha3Code: 'IRQ',
+    numericCode: '368'
+  },
+  {
+    name: 'Irland',
+    alpha2Code: 'IE',
+    alpha3Code: 'IRL',
+    numericCode: '372'
+  },
+  {
+    name: 'Israel',
+    alpha2Code: 'IL',
+    alpha3Code: 'ISR',
+    numericCode: '376'
+  },
+  {
+    name: 'Italien',
+    alpha2Code: 'IT',
+    alpha3Code: 'ITA',
+    numericCode: '380'
+  },
+  {
+    name: 'Jamaika',
+    alpha2Code: 'JM',
+    alpha3Code: 'JAM',
+    numericCode: '388'
+  },
+  {
+    name: 'Japan',
+    alpha2Code: 'JP',
+    alpha3Code: 'JPN',
+    numericCode: '392'
+  },
+  {
+    name: 'Jersey',
+    alpha2Code: 'JE',
+    alpha3Code: 'JEY',
+    numericCode: '832'
+  },
+  {
+    name: 'Jordan',
+    alpha2Code: 'JO',
+    alpha3Code: 'JOR',
+    numericCode: '400'
+  },
+  {
+    name: 'Kasachstan',
+    alpha2Code: 'KZ',
+    alpha3Code: 'KAZ',
+    numericCode: '398'
+  },
+  {
+    name: 'Kenia',
+    alpha2Code: 'KE',
+    alpha3Code: 'KEN',
+    numericCode: '404'
+  },
+  {
+    name: 'Kiribati',
+    alpha2Code: 'KI',
+    alpha3Code: 'KIR',
+    numericCode: '296'
+  },
+  {
+    name: 'Korea (Demokratische Volksrepublik)',
+    alpha2Code: 'KP',
+    alpha3Code: 'PRK',
+    numericCode: '408'
+  },
+  {
+    name: 'Korea (Republik)  t',
+    alpha2Code: 'KR',
+    alpha3Code: 'KOR',
+    numericCode: '410'
+  },
+  {
+    name: 'Kuwait',
+    alpha2Code: 'KW',
+    alpha3Code: 'KWT',
+    numericCode: '414'
+  },
+  {
+    name: 'Kirgisistan',
+    alpha2Code: 'KG',
+    alpha3Code: 'KGZ',
+    numericCode: '417'
+  },
+  {
+    name: 'Laos',
+    alpha2Code: 'LA',
+    alpha3Code: 'LAO',
+    numericCode: '418'
+  },
+  {
+    name: 'Lettland',
+    alpha2Code: 'LV',
+    alpha3Code: 'LVA',
+    numericCode: '428'
+  },
+  {
+    name: 'Libanon',
+    alpha2Code: 'LB',
+    alpha3Code: 'LBN',
+    numericCode: '422'
+  },
+  {
+    name: 'Lesotho',
+    alpha2Code: 'LS',
+    alpha3Code: 'LSO',
+    numericCode: '426'
+  },
+  {
+    name: 'Liberia',
+    alpha2Code: 'LR',
+    alpha3Code: 'LBR',
+    numericCode: '430'
+  },
+  {
+    name: 'Libyen',
+    alpha2Code: 'LY',
+    alpha3Code: 'LBY',
+    numericCode: '434'
+  },
+  {
+    name: 'Liechtenstein',
+    alpha2Code: 'LI',
+    alpha3Code: 'LIE',
+    numericCode: '438'
+  },
+  {
+    name: 'Litauen',
+    alpha2Code: 'LT',
+    alpha3Code: 'LTU',
+    numericCode: '440'
+  },
+  {
+    name: 'Luxemburg',
+    alpha2Code: 'LU',
+    alpha3Code: 'LUX',
+    numericCode: '442'
+  },
+  {
     name: 'Macao',
     alpha2Code: 'MO',
     alpha3Code: 'MAC',
     numericCode: '446'
   },
-    {
-      name: 'Madagaskar',
-      alpha2Code: 'MG',
-      alpha3Code: 'MDG',
-      numericCode: '450'
-    },
-    {
-      name: 'Malawi',
-      alpha2Code: 'MW',
-      alpha3Code: 'MWI',
-      numericCode: '454'
-    },
-    {
-      name: 'Malaysia',
-      alpha2Code: 'MY',
-      alpha3Code: 'MYS',
-      numericCode: '458'
-    },
-    {
-      name: 'Malediven',
-      alpha2Code: 'MV',
-      alpha3Code: 'MDV',
-      numericCode: '462'
-    },
-    {
-      name: 'Mali',
-      alpha2Code: 'ML',
-      alpha3Code: 'MLI',
-      numericCode: '466'
-    },
-    {
-      name: 'Malta',
-      alpha2Code: 'MT',
-      alpha3Code: 'MLT',
-      numericCode: '470'
-    },
-    {
-      name: 'Mauretanien',
-      alpha2Code: 'MR',
-      alpha3Code: 'MRT',
-      numericCode: '478'
-    },
-    {
-      name: 'Mauritius',
-      alpha2Code: 'MU',
-      alpha3Code: 'MUS',
-      numericCode: '480'
-    },
-    {
-      name: 'Mexiko',
-      alpha2Code: 'MX',
-      alpha3Code: 'MEX',
-      numericCode: '484'
-    },
-    {
-      name: 'Moldawien',
-      alpha2Code: 'MD',
-      alpha3Code: 'MDA',
-      numericCode: '498'
-    },
-    {
-      name: 'Monaco',
-      alpha2Code: 'MC',
-      alpha3Code: 'MCO',
-      numericCode: '492'
-    },
-    {
-      name: 'Mongolei',
-      alpha2Code: 'MN',
-      alpha3Code: 'MNG',
-      numericCode: '496'
-    },
-    {
-      name: 'Montenegro',
-      alpha2Code: 'ME',
-      alpha3Code: 'MNE',
-      numericCode: '499'
-    },
-    {
-      name: 'Marokko',
-      alpha2Code: 'MA',
-      alpha3Code: 'MAR',
-      numericCode: '504'
-    },
-    {
-      name: 'Mosambik',
-      alpha2Code: 'MZ',
-      alpha3Code: 'MOZ',
-      numericCode: '508'
-    },
-    {
-      name: 'Myanmar',
-      alpha2Code: 'MM',
-      alpha3Code: 'MMR',
-      numericCode: '104'
-    },
-    {
-      name: 'Namibia',
-      alpha2Code: 'NA',
-      alpha3Code: 'NAM',
-      numericCode: '516'
-    },
-    {
-      name: 'Nauru',
-      alpha2Code: 'NR',
-      alpha3Code: 'NRU',
-      numericCode: '520'
-    },
-    {
-      name: 'Nepal',
-      alpha2Code: 'NP',
-      alpha3Code: 'NPL',
-      numericCode: '524'
-    },
-    {
-      name: 'Niederlande',
-      alpha2Code: 'NL',
-      alpha3Code: 'NLD',
-      numericCode: '528'
-    },
-    {
-      name: 'Neukaledonien',
-      alpha2Code: 'NC',
-      alpha3Code: 'NCL',
-      numericCode: '540'
-    },
-    {
-      name: 'Neuseeland',
-      alpha2Code: 'NZ',
-      alpha3Code: 'NZL',
-      numericCode: '554'
-    },
-    {
-      name: 'Nicaragua',
-      alpha2Code: 'NI',
-      alpha3Code: 'NIC',
-      numericCode: '558'
-    },
-    {
-      name: 'Niger',
-      alpha2Code: 'NE',
-      alpha3Code: 'NER',
-      numericCode: '562'
-    },
-    {
-      name: 'Nigeria',
-      alpha2Code: 'NG',
-      alpha3Code: 'NGA',
-      numericCode: '566'
-    },
-    {
-      name: 'Norwegen',
-      alpha2Code: 'NO',
-      alpha3Code: 'NOR',
-      numericCode: '578'
-    },
-    {
-      name: 'Oman',
-      alpha2Code: 'OM',
-      alpha3Code: 'OMN',
-      numericCode: '512'
-    },
-    {
-      name: 'Pakistan',
-      alpha2Code: 'PK',
-      alpha3Code: 'PAK',
-      numericCode: '586'
-    },
-    {
-      name: 'Palau',
-      alpha2Code: 'PW',
-      alpha3Code: 'PLW',
-      numericCode: '585'
-    },
-    {
-      name: 'Palästina',
-      alpha2Code: 'PS',
-      alpha3Code: 'PSE',
-      numericCode: '275'
-    },
-    {
-      name: 'Panama',
-      alpha2Code: 'PA',
-      alpha3Code: 'PAN',
-      numericCode: '591'
-    },
-    {
-      name: 'Papua-Neuguinea',
-      alpha2Code: 'PG',
-      alpha3Code: 'PNG',
-      numericCode: '598'
-    },
-    {
-      name: 'Paraguay',
-      alpha2Code: 'PY',
-      alpha3Code: 'PRY',
-      numericCode: '600'
-    },
-    {
-      name: 'Peru',
-      alpha2Code: 'PE',
-      alpha3Code: 'PER',
-      numericCode: '604'
-    },
-    {
-      name: 'Philippinen',
-      alpha2Code: 'PH',
-      alpha3Code: 'PHL',
-      numericCode: '608'
-    },
-    {
-      name: 'Polen',
-      alpha2Code: 'PL',
-      alpha3Code: 'POL',
-      numericCode: '616'
-    },
-    {
-      name: 'Portugal',
-      alpha2Code: 'PT',
-      alpha3Code: 'PRT',
-      numericCode: '620'
-    }, {
+  {
+    name: 'Madagaskar',
+    alpha2Code: 'MG',
+    alpha3Code: 'MDG',
+    numericCode: '450'
+  },
+  {
+    name: 'Malawi',
+    alpha2Code: 'MW',
+    alpha3Code: 'MWI',
+    numericCode: '454'
+  },
+  {
+    name: 'Malaysia',
+    alpha2Code: 'MY',
+    alpha3Code: 'MYS',
+    numericCode: '458'
+  },
+  {
+    name: 'Malediven',
+    alpha2Code: 'MV',
+    alpha3Code: 'MDV',
+    numericCode: '462'
+  },
+  {
+    name: 'Mali',
+    alpha2Code: 'ML',
+    alpha3Code: 'MLI',
+    numericCode: '466'
+  },
+  {
+    name: 'Malta',
+    alpha2Code: 'MT',
+    alpha3Code: 'MLT',
+    numericCode: '470'
+  },
+  {
+    name: 'Mauretanien',
+    alpha2Code: 'MR',
+    alpha3Code: 'MRT',
+    numericCode: '478'
+  },
+  {
+    name: 'Mauritius',
+    alpha2Code: 'MU',
+    alpha3Code: 'MUS',
+    numericCode: '480'
+  },
+  {
+    name: 'Mexiko',
+    alpha2Code: 'MX',
+    alpha3Code: 'MEX',
+    numericCode: '484'
+  },
+  {
+    name: 'Moldawien',
+    alpha2Code: 'MD',
+    alpha3Code: 'MDA',
+    numericCode: '498'
+  },
+  {
+    name: 'Monaco',
+    alpha2Code: 'MC',
+    alpha3Code: 'MCO',
+    numericCode: '492'
+  },
+  {
+    name: 'Mongolei',
+    alpha2Code: 'MN',
+    alpha3Code: 'MNG',
+    numericCode: '496'
+  },
+  {
+    name: 'Montenegro',
+    alpha2Code: 'ME',
+    alpha3Code: 'MNE',
+    numericCode: '499'
+  },
+  {
+    name: 'Marokko',
+    alpha2Code: 'MA',
+    alpha3Code: 'MAR',
+    numericCode: '504'
+  },
+  {
+    name: 'Mosambik',
+    alpha2Code: 'MZ',
+    alpha3Code: 'MOZ',
+    numericCode: '508'
+  },
+  {
+    name: 'Myanmar',
+    alpha2Code: 'MM',
+    alpha3Code: 'MMR',
+    numericCode: '104'
+  },
+  {
+    name: 'Namibia',
+    alpha2Code: 'NA',
+    alpha3Code: 'NAM',
+    numericCode: '516'
+  },
+  {
+    name: 'Nauru',
+    alpha2Code: 'NR',
+    alpha3Code: 'NRU',
+    numericCode: '520'
+  },
+  {
+    name: 'Nepal',
+    alpha2Code: 'NP',
+    alpha3Code: 'NPL',
+    numericCode: '524'
+  },
+  {
+    name: 'Niederlande',
+    alpha2Code: 'NL',
+    alpha3Code: 'NLD',
+    numericCode: '528'
+  },
+  {
+    name: 'Neukaledonien',
+    alpha2Code: 'NC',
+    alpha3Code: 'NCL',
+    numericCode: '540'
+  },
+  {
+    name: 'Neuseeland',
+    alpha2Code: 'NZ',
+    alpha3Code: 'NZL',
+    numericCode: '554'
+  },
+  {
+    name: 'Nicaragua',
+    alpha2Code: 'NI',
+    alpha3Code: 'NIC',
+    numericCode: '558'
+  },
+  {
+    name: 'Niger',
+    alpha2Code: 'NE',
+    alpha3Code: 'NER',
+    numericCode: '562'
+  },
+  {
+    name: 'Nigeria',
+    alpha2Code: 'NG',
+    alpha3Code: 'NGA',
+    numericCode: '566'
+  },
+  {
+    name: 'Norwegen',
+    alpha2Code: 'NO',
+    alpha3Code: 'NOR',
+    numericCode: '578'
+  },
+  {
+    name: 'Oman',
+    alpha2Code: 'OM',
+    alpha3Code: 'OMN',
+    numericCode: '512'
+  },
+  {
+    name: 'Pakistan',
+    alpha2Code: 'PK',
+    alpha3Code: 'PAK',
+    numericCode: '586'
+  },
+  {
+    name: 'Palau',
+    alpha2Code: 'PW',
+    alpha3Code: 'PLW',
+    numericCode: '585'
+  },
+  {
+    name: 'Palästina',
+    alpha2Code: 'PS',
+    alpha3Code: 'PSE',
+    numericCode: '275'
+  },
+  {
+    name: 'Panama',
+    alpha2Code: 'PA',
+    alpha3Code: 'PAN',
+    numericCode: '591'
+  },
+  {
+    name: 'Papua-Neuguinea',
+    alpha2Code: 'PG',
+    alpha3Code: 'PNG',
+    numericCode: '598'
+  },
+  {
+    name: 'Paraguay',
+    alpha2Code: 'PY',
+    alpha3Code: 'PRY',
+    numericCode: '600'
+  },
+  {
+    name: 'Peru',
+    alpha2Code: 'PE',
+    alpha3Code: 'PER',
+    numericCode: '604'
+  },
+  {
+    name: 'Philippinen',
+    alpha2Code: 'PH',
+    alpha3Code: 'PHL',
+    numericCode: '608'
+  },
+  {
+    name: 'Polen',
+    alpha2Code: 'PL',
+    alpha3Code: 'POL',
+    numericCode: '616'
+  },
+  {
+    name: 'Portugal',
+    alpha2Code: 'PT',
+    alpha3Code: 'PRT',
+    numericCode: '620'
+  },
+  {
     name: 'Puerto Rico',
     alpha2Code: 'PR',
     alpha3Code: 'PRI',
     numericCode: '630'
   },
-    {
-      name: 'Katar',
-      alpha2Code: 'QA',
-      alpha3Code: 'QAT',
-      numericCode: '634'
-    },
-    {
-      name: 'Republik Nordmakedonien',
-      alpha2Code: 'MK',
-      alpha3Code: 'MKD',
-      numericCode: '807'
-    },
-    {
-      name: 'Rumänien',
-      alpha2Code: 'RO',
-      alpha3Code: 'ROU',
-      numericCode: '642'
-    },
-    {
-      name: 'Russische Föderation (the)',
-      alpha2Code: 'RU',
-      alpha3Code: 'RUS',
-      numericCode: '643'
-    },
-    {
-      name: 'Ruanda',
-      alpha2Code: 'RW',
-      alpha3Code: 'RWA',
-      numericCode: '646'
-    },
-    {
-      name: 'Saint Kitts und Nevis',
-      alpha2Code: 'KN',
-      alpha3Code: 'KNA',
-      numericCode: '659'
-    },
-    {
-      name: 'St. Lucia',
-      alpha2Code: 'LC',
-      alpha3Code: 'LCA',
-      numericCode: '662'
-    },
-    {
-      name: 'St. Vincent und die Grenadinen',
-      alpha2Code: 'VC',
-      alpha3Code: 'VCT',
-      numericCode: '670'
-    },
-    {
-      name: 'Samoa',
-      alpha2Code: 'WS',
-      alpha3Code: 'WSM',
-      numericCode: '882'
-    },
-    {
-      name: 'San Marino',
-      alpha2Code: 'SM',
-      alpha3Code: 'SMR',
-      numericCode: '674'
-    },
-    {
-      name: 'Sao Tome and Principe',
-      alpha2Code: 'ST',
-      alpha3Code: 'STP',
-      numericCode: '678'
-    },
-    {
-      name: 'Saudi-Arabien',
-      alpha2Code: 'SA',
-      alpha3Code: 'SAU',
-      numericCode: '682'
-    },
-    {
-      name: 'Senegal',
-      alpha2Code: 'SN',
-      alpha3Code: 'SEN',
-      numericCode: '686'
-    },
-    {
-      name: 'Serbien',
-      alpha2Code: 'RS',
-      alpha3Code: 'SRB',
-      numericCode: '688'
-    },
-    {
-      name: 'Seychellen',
-      alpha2Code: 'SC',
-      alpha3Code: 'SYC',
-      numericCode: '690'
-    },
-    {
-      name: 'Sierra Leone',
-      alpha2Code: 'SL',
-      alpha3Code: 'SLE',
-      numericCode: '694'
-    },
-    {
-      name: 'Singapur',
-      alpha2Code: 'SG',
-      alpha3Code: 'SGP',
-      numericCode: '702'
-    },
-    {
-      name: 'Slowakei',
-      alpha2Code: 'SK',
-      alpha3Code: 'SVK',
-      numericCode: '703'
-    },
-    {
-      name: 'Slowenien',
-      alpha2Code: 'SI',
-      alpha3Code: 'SVN',
-      numericCode: '705'
-    },
-    {
-      name: 'Salomonen',
-      alpha2Code: 'SB',
-      alpha3Code: 'SLB',
-      numericCode: '090'
-    },
-    {
-      name: 'Somalia',
-      alpha2Code: 'SO',
-      alpha3Code: 'SOM',
-      numericCode: '706'
-    },
-    {
-      name: 'Südafrika',
-      alpha2Code: 'ZA',
-      alpha3Code: 'ZAF',
-      numericCode: '710'
-    },
-    {
-      name: 'Südsudan',
-      alpha2Code: 'SS',
-      alpha3Code: 'SSD',
-      numericCode: '728'
-    },
-    {
-      name: 'Spanien',
-      alpha2Code: 'ES',
-      alpha3Code: 'ESP',
-      numericCode: '724'
-    },
-    {
-      name: 'Sri Lanka',
-      alpha2Code: 'LK',
-      alpha3Code: 'LKA',
-      numericCode: '144'
-    },
-    {
-      name: 'Sudan',
-      alpha2Code: 'SD',
-      alpha3Code: 'SDN',
-      numericCode: '729'
-    },
-    {
-      name: 'Suriname',
-      alpha2Code: 'SR',
-      alpha3Code: 'SUR',
-      numericCode: '740'
-    },
-    {
-      name: 'Schweden',
-      alpha2Code: 'SE',
-      alpha3Code: 'SWE',
-      numericCode: '752'
-    },
-    {
-      name: 'Schweiz',
-      alpha2Code: 'CH',
-      alpha3Code: 'CHE',
-      numericCode: '756'
-    },
-    {
-      name: 'Syrische Arabische Republik',
-      alpha2Code: 'SY',
-      alpha3Code: 'SYR',
-      numericCode: '760'
-    },
-    {
-      name: 'Taiwan',
-      alpha2Code: 'TW',
-      alpha3Code: 'TWN',
-      numericCode: '158'
-    },
-    {
-      name: 'Tadschikistan',
-      alpha2Code: 'TJ',
-      alpha3Code: 'TJK',
-      numericCode: '762'
-    },
-    {
-      name: 'Tansania',
-      alpha2Code: 'TZ',
-      alpha3Code: 'TZA',
-      numericCode: '834'
-    },
-    {
-      name: 'Thailand',
-      alpha2Code: 'TH',
-      alpha3Code: 'THA',
-      numericCode: '764'
-    },
-    {
-      name: 'Timor-Leste',
-      alpha2Code: 'TL',
-      alpha3Code: 'TLS',
-      numericCode: '626'
-    },
-    {
-      name: 'Togo',
-      alpha2Code: 'TG',
-      alpha3Code: 'TGO',
-      numericCode: '768'
-    }, {
+  {
+    name: 'Katar',
+    alpha2Code: 'QA',
+    alpha3Code: 'QAT',
+    numericCode: '634'
+  },
+  {
+    name: 'Republik Nordmakedonien',
+    alpha2Code: 'MK',
+    alpha3Code: 'MKD',
+    numericCode: '807'
+  },
+  {
+    name: 'Rumänien',
+    alpha2Code: 'RO',
+    alpha3Code: 'ROU',
+    numericCode: '642'
+  },
+  {
+    name: 'Russische Föderation (the)',
+    alpha2Code: 'RU',
+    alpha3Code: 'RUS',
+    numericCode: '643'
+  },
+  {
+    name: 'Ruanda',
+    alpha2Code: 'RW',
+    alpha3Code: 'RWA',
+    numericCode: '646'
+  },
+  {
+    name: 'Saint Kitts und Nevis',
+    alpha2Code: 'KN',
+    alpha3Code: 'KNA',
+    numericCode: '659'
+  },
+  {
+    name: 'St. Lucia',
+    alpha2Code: 'LC',
+    alpha3Code: 'LCA',
+    numericCode: '662'
+  },
+  {
+    name: 'St. Vincent und die Grenadinen',
+    alpha2Code: 'VC',
+    alpha3Code: 'VCT',
+    numericCode: '670'
+  },
+  {
+    name: 'Samoa',
+    alpha2Code: 'WS',
+    alpha3Code: 'WSM',
+    numericCode: '882'
+  },
+  {
+    name: 'San Marino',
+    alpha2Code: 'SM',
+    alpha3Code: 'SMR',
+    numericCode: '674'
+  },
+  {
+    name: 'Sao Tome and Principe',
+    alpha2Code: 'ST',
+    alpha3Code: 'STP',
+    numericCode: '678'
+  },
+  {
+    name: 'Saudi-Arabien',
+    alpha2Code: 'SA',
+    alpha3Code: 'SAU',
+    numericCode: '682'
+  },
+  {
+    name: 'Senegal',
+    alpha2Code: 'SN',
+    alpha3Code: 'SEN',
+    numericCode: '686'
+  },
+  {
+    name: 'Serbien',
+    alpha2Code: 'RS',
+    alpha3Code: 'SRB',
+    numericCode: '688'
+  },
+  {
+    name: 'Seychellen',
+    alpha2Code: 'SC',
+    alpha3Code: 'SYC',
+    numericCode: '690'
+  },
+  {
+    name: 'Sierra Leone',
+    alpha2Code: 'SL',
+    alpha3Code: 'SLE',
+    numericCode: '694'
+  },
+  {
+    name: 'Singapur',
+    alpha2Code: 'SG',
+    alpha3Code: 'SGP',
+    numericCode: '702'
+  },
+  {
+    name: 'Slowakei',
+    alpha2Code: 'SK',
+    alpha3Code: 'SVK',
+    numericCode: '703'
+  },
+  {
+    name: 'Slowenien',
+    alpha2Code: 'SI',
+    alpha3Code: 'SVN',
+    numericCode: '705'
+  },
+  {
+    name: 'Salomonen',
+    alpha2Code: 'SB',
+    alpha3Code: 'SLB',
+    numericCode: '090'
+  },
+  {
+    name: 'Somalia',
+    alpha2Code: 'SO',
+    alpha3Code: 'SOM',
+    numericCode: '706'
+  },
+  {
+    name: 'Südafrika',
+    alpha2Code: 'ZA',
+    alpha3Code: 'ZAF',
+    numericCode: '710'
+  },
+  {
+    name: 'Südsudan',
+    alpha2Code: 'SS',
+    alpha3Code: 'SSD',
+    numericCode: '728'
+  },
+  {
+    name: 'Spanien',
+    alpha2Code: 'ES',
+    alpha3Code: 'ESP',
+    numericCode: '724'
+  },
+  {
+    name: 'Sri Lanka',
+    alpha2Code: 'LK',
+    alpha3Code: 'LKA',
+    numericCode: '144'
+  },
+  {
+    name: 'Sudan',
+    alpha2Code: 'SD',
+    alpha3Code: 'SDN',
+    numericCode: '729'
+  },
+  {
+    name: 'Suriname',
+    alpha2Code: 'SR',
+    alpha3Code: 'SUR',
+    numericCode: '740'
+  },
+  {
+    name: 'Schweden',
+    alpha2Code: 'SE',
+    alpha3Code: 'SWE',
+    numericCode: '752'
+  },
+  {
+    name: 'Schweiz',
+    alpha2Code: 'CH',
+    alpha3Code: 'CHE',
+    numericCode: '756'
+  },
+  {
+    name: 'Syrische Arabische Republik',
+    alpha2Code: 'SY',
+    alpha3Code: 'SYR',
+    numericCode: '760'
+  },
+  {
+    name: 'Taiwan',
+    alpha2Code: 'TW',
+    alpha3Code: 'TWN',
+    numericCode: '158'
+  },
+  {
+    name: 'Tadschikistan',
+    alpha2Code: 'TJ',
+    alpha3Code: 'TJK',
+    numericCode: '762'
+  },
+  {
+    name: 'Tansania',
+    alpha2Code: 'TZ',
+    alpha3Code: 'TZA',
+    numericCode: '834'
+  },
+  {
+    name: 'Thailand',
+    alpha2Code: 'TH',
+    alpha3Code: 'THA',
+    numericCode: '764'
+  },
+  {
+    name: 'Timor-Leste',
+    alpha2Code: 'TL',
+    alpha3Code: 'TLS',
+    numericCode: '626'
+  },
+  {
+    name: 'Togo',
+    alpha2Code: 'TG',
+    alpha3Code: 'TGO',
+    numericCode: '768'
+  },
+  {
     name: 'Tonga',
     alpha2Code: 'TO',
     alpha3Code: 'TON',
     numericCode: '776'
   },
-    {
-      name: 'Trinidad und Tobago',
-      alpha2Code: 'TT',
-      alpha3Code: 'TTO',
-      numericCode: '780'
-    },
-    {
-      name: 'Tunesien',
-      alpha2Code: 'TN',
-      alpha3Code: 'TUN',
-      numericCode: '788'
-    },
-    {
-      name: 'Türkei',
-      alpha2Code: 'TR',
-      alpha3Code: 'TUR',
-      numericCode: '792'
-    },
-    {
-      name: 'Turkmenistan',
-      alpha2Code: 'TM',
-      alpha3Code: 'TKM',
-      numericCode: '795'
-    },
-    {
-      name: 'Tuvalu',
-      alpha2Code: 'TV',
-      alpha3Code: 'TÜV',
-      numericCode: '798'
-    },
-    {
-      name: 'Uganda',
-      alpha2Code: 'UG',
-      alpha3Code: 'UGA',
-      numericCode: '800'
-    },
-    {
-      name: 'Ukraine',
-      alpha2Code: 'UA',
-      alpha3Code: 'UKR',
-      numericCode: '804'
-    },
-    {
-      name: 'Vereinigte Arabische Emirate',
-      alpha2Code: 'AE',
-      alpha3Code: 'ARE',
-      numericCode: '784'
-    },
-    {
-      name: 'Vereinigtes Königreich',
-      alpha2Code: 'GB',
-      alpha3Code: 'GBR',
-      numericCode: '826'
-    },
-    {
-      name: 'Vereinigte Staaten von Amerika',
-      alpha2Code: 'US',
-      alpha3Code: 'USA',
-      numericCode: '840'
-    },
-    {
-      name: 'Uruguay',
-      alpha2Code: 'UY',
-      alpha3Code: 'URY',
-      numericCode: '858'
-    },
-    {
-      name: 'Usbekistan',
-      alpha2Code: 'UZ',
-      alpha3Code: 'UZB',
-      numericCode: '860'
-    },
-    {
-      name: 'Vanuatu',
-      alpha2Code: 'VU',
-      alpha3Code: 'VUT',
-      numericCode: '548'
-    },
-    {
-      name: 'Venezuela',
-      alpha2Code: 'VE',
-      alpha3Code: 'VEN',
-      numericCode: '862'
-    },
-    {
-      name: 'Vietnam',
-      alpha2Code: 'VN',
-      alpha3Code: 'VNM',
-      numericCode: '704'
-    },
-    {
-      name: 'Jemen',
-      alpha2Code: 'YE',
-      alpha3Code: 'YEM',
-      numericCode: '887'
-    },
-    {
-      name: 'Sambia',
-      alpha2Code: 'ZM',
-      alpha3Code: 'ZMB',
-      numericCode: '894'
-    },
-    {
-      name: 'Simbabwe',
-      alpha2Code: 'ZW',
-      alpha3Code: 'ZWE',
-      numericCode: '716'
-    }
-  ]
-;
+  {
+    name: 'Trinidad und Tobago',
+    alpha2Code: 'TT',
+    alpha3Code: 'TTO',
+    numericCode: '780'
+  },
+  {
+    name: 'Tunesien',
+    alpha2Code: 'TN',
+    alpha3Code: 'TUN',
+    numericCode: '788'
+  },
+  {
+    name: 'Türkei',
+    alpha2Code: 'TR',
+    alpha3Code: 'TUR',
+    numericCode: '792'
+  },
+  {
+    name: 'Turkmenistan',
+    alpha2Code: 'TM',
+    alpha3Code: 'TKM',
+    numericCode: '795'
+  },
+  {
+    name: 'Tuvalu',
+    alpha2Code: 'TV',
+    alpha3Code: 'TÜV',
+    numericCode: '798'
+  },
+  {
+    name: 'Uganda',
+    alpha2Code: 'UG',
+    alpha3Code: 'UGA',
+    numericCode: '800'
+  },
+  {
+    name: 'Ukraine',
+    alpha2Code: 'UA',
+    alpha3Code: 'UKR',
+    numericCode: '804'
+  },
+  {
+    name: 'Vereinigte Arabische Emirate',
+    alpha2Code: 'AE',
+    alpha3Code: 'ARE',
+    numericCode: '784'
+  },
+  {
+    name: 'Vereinigtes Königreich',
+    alpha2Code: 'GB',
+    alpha3Code: 'GBR',
+    numericCode: '826'
+  },
+  {
+    name: 'Vereinigte Staaten von Amerika',
+    alpha2Code: 'US',
+    alpha3Code: 'USA',
+    numericCode: '840'
+  },
+  {
+    name: 'Uruguay',
+    alpha2Code: 'UY',
+    alpha3Code: 'URY',
+    numericCode: '858'
+  },
+  {
+    name: 'Usbekistan',
+    alpha2Code: 'UZ',
+    alpha3Code: 'UZB',
+    numericCode: '860'
+  },
+  {
+    name: 'Vanuatu',
+    alpha2Code: 'VU',
+    alpha3Code: 'VUT',
+    numericCode: '548'
+  },
+  {
+    name: 'Venezuela',
+    alpha2Code: 'VE',
+    alpha3Code: 'VEN',
+    numericCode: '862'
+  },
+  {
+    name: 'Vietnam',
+    alpha2Code: 'VN',
+    alpha3Code: 'VNM',
+    numericCode: '704'
+  },
+  {
+    name: 'Jemen',
+    alpha2Code: 'YE',
+    alpha3Code: 'YEM',
+    numericCode: '887'
+  },
+  {
+    name: 'Sambia',
+    alpha2Code: 'ZM',
+    alpha3Code: 'ZMB',
+    numericCode: '894'
+  },
+  {
+    name: 'Simbabwe',
+    alpha2Code: 'ZW',
+    alpha3Code: 'ZWE',
+    numericCode: '716'
+  }
+];

--- a/projects/angular-material-extensions/select-country/src/lib/i18n/en.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/i18n/en.ts
@@ -1,1224 +1,1222 @@
 import { Country } from '../mat-select-country.component';
 
-export const COUNTRIES_DB: Country[] =
-  [
-    {
-      name: 'Afghanistan',
-      alpha2Code: 'AF',
-      alpha3Code: 'AFG',
-      numericCode: '004'
-    },
-    {
-      name: 'Albania',
-      alpha2Code: 'AL',
-      alpha3Code: 'ALB',
-      numericCode: '008'
-    },
-    {
-      name: 'Algeria',
-      alpha2Code: 'DZ',
-      alpha3Code: 'DZA',
-      numericCode: '012'
-    },
-    {
-      name: 'American Samoa',
-      alpha2Code: 'AS',
-      alpha3Code: 'ASM',
-      numericCode: '016'
-    },
-    {
-      name: 'Andorra',
-      alpha2Code: 'AD',
-      alpha3Code: 'AND',
-      numericCode: '020'
-    },
-    {
-      name: 'Angola',
-      alpha2Code: 'AO',
-      alpha3Code: 'AGO',
-      numericCode: '024'
-    },
-    {
-      name: 'Antigua and Barbuda',
-      alpha2Code: 'AG',
-      alpha3Code: 'ATG',
-      numericCode: '028'
-    },
-    {
-      name: 'Argentina',
-      alpha2Code: 'AR',
-      alpha3Code: 'ARG',
-      numericCode: '032'
-    },
-    {
-      name: 'Armenia',
-      alpha2Code: 'AM',
-      alpha3Code: 'ARM',
-      numericCode: '051'
-    },
-    {
-      name: 'Australia',
-      alpha2Code: 'AU',
-      alpha3Code: 'AUS',
-      numericCode: '036'
-    },
-    {
-      name: 'Austria',
-      alpha2Code: 'AT',
-      alpha3Code: 'AUT',
-      numericCode: '040'
-    },
-    {
-      name: 'Azerbaijan',
-      alpha2Code: 'AZ',
-      alpha3Code: 'AZE',
-      numericCode: '031'
-    },
-    {
-      name: 'Bahamas',
-      alpha2Code: 'BS',
-      alpha3Code: 'BHS',
-      numericCode: '044'
-    },
-    {
-      name: 'Bahrain',
-      alpha2Code: 'BH',
-      alpha3Code: 'BHR',
-      numericCode: '048'
-    },
-    {
-      name: 'Bangladesh',
-      alpha2Code: 'BD',
-      alpha3Code: 'BGD',
-      numericCode: '050'
-    },
-    {
-      name: 'Barbados',
-      alpha2Code: 'BB',
-      alpha3Code: 'BRB',
-      numericCode: '052'
-    },
-    {
-      name: 'Belarus',
-      alpha2Code: 'BY',
-      alpha3Code: 'BLR',
-      numericCode: '112'
-    },
-    {
-      name: 'Belgium',
-      alpha2Code: 'BE',
-      alpha3Code: 'BEL',
-      numericCode: '056'
-    },
-    {
-      name: 'Belize',
-      alpha2Code: 'BZ',
-      alpha3Code: 'BLZ',
-      numericCode: '084'
-    },
-    {
-      name: 'Benin',
-      alpha2Code: 'BJ',
-      alpha3Code: 'BEN',
-      numericCode: '204'
-    },
-    {
-      name: 'Bermuda',
-      alpha2Code: 'BM',
-      alpha3Code: 'BMU',
-      numericCode: '060'
-    },
-    {
-      name: 'Bhutan',
-      alpha2Code: 'BT',
-      alpha3Code: 'BTN',
-      numericCode: '064'
-    },
-    {
-      name: 'Bolivia',
-      alpha2Code: 'BO',
-      alpha3Code: 'BOL',
-      numericCode: '068'
-    },
-    {
-      name: 'Bonaire, Sint Eustatius and Saba',
-      alpha2Code: 'BQ',
-      alpha3Code: 'BES',
-      numericCode: '535'
-    },
-    {
-      name: 'Bosnia and Herzegovina',
-      alpha2Code: 'BA',
-      alpha3Code: 'BIH',
-      numericCode: '070'
-    },
-    {
-      name: 'Botswana',
-      alpha2Code: 'BW',
-      alpha3Code: 'BWA',
-      numericCode: '072'
-    },
-    {
-      name: 'Bouvet Island',
-      alpha2Code: 'BV',
-      alpha3Code: 'BVT',
-      numericCode: '074'
-    },
-    {
-      name: 'Brazil',
-      alpha2Code: 'BR',
-      alpha3Code: 'BRA',
-      numericCode: '076'
-    },
-    {
-      name: 'Brunei',
-      alpha2Code: 'BN',
-      alpha3Code: 'BRN',
-      numericCode: '096'
-    },
-    {
-      name: 'Bulgaria',
-      alpha2Code: 'BG',
-      alpha3Code: 'BGR',
-      numericCode: '100'
-    },
-    {
-      name: 'Burkina Faso',
-      alpha2Code: 'BF',
-      alpha3Code: 'BFA',
-      numericCode: '854'
-    },
-    {
-      name: 'Burundi',
-      alpha2Code: 'BI',
-      alpha3Code: 'BDI',
-      numericCode: '108'
-    },
-    {
-      name: 'Cabo Verde',
-      alpha2Code: 'CV',
-      alpha3Code: 'CPV',
-      numericCode: '132'
-    },
-    {
-      name: 'Cambodia',
-      alpha2Code: 'KH',
-      alpha3Code: 'KHM',
-      numericCode: '116'
-    },
-    {
-      name: 'Cameroon',
-      alpha2Code: 'CM',
-      alpha3Code: 'CMR',
-      numericCode: '120'
-    },
-    {
-      name: 'Canada',
-      alpha2Code: 'CA',
-      alpha3Code: 'CAN',
-      numericCode: '124'
-    },
-    {
-      name: 'Central African Republic',
-      alpha2Code: 'CF',
-      alpha3Code: 'CAF',
-      numericCode: '140'
-    },
-    {
-      name: 'Chad',
-      alpha2Code: 'TD',
-      alpha3Code: 'TCD',
-      numericCode: '148'
-    },
-    {
-      name: 'Chile',
-      alpha2Code: 'CL',
-      alpha3Code: 'CHL',
-      numericCode: '152'
-    },
-    {
-      name: 'China',
-      alpha2Code: 'CN',
-      alpha3Code: 'CHN',
-      numericCode: '156'
-    },
-    {
-      name: 'Colombia',
-      alpha2Code: 'CO',
-      alpha3Code: 'COL',
-      numericCode: '170'
-    },
-    {
-      name: 'Congo (Democratic Republic of the)',
-      alpha2Code: 'CD',
-      alpha3Code: 'COD',
-      numericCode: '180'
-    },
-    {
-      name: 'Congo (Republic of the)',
-      alpha2Code: 'CG',
-      alpha3Code: 'COG',
-      numericCode: '178'
-    },
-    {
-      name: 'Costa Rica',
-      alpha2Code: 'CR',
-      alpha3Code: 'CRI',
-      numericCode: '188'
-    },
-    {
-      name: 'Croatia',
-      alpha2Code: 'HR',
-      alpha3Code: 'HRV',
-      numericCode: '191'
-    },
-    {
-      name: 'Cuba',
-      alpha2Code: 'CU',
-      alpha3Code: 'CUB',
-      numericCode: '192'
-    },
-    {
-      name: 'Cyprus',
-      alpha2Code: 'CY',
-      alpha3Code: 'CYP',
-      numericCode: '196'
-    },
-    {
-      name: 'Czechia',
-      alpha2Code: 'CZ',
-      alpha3Code: 'CZE',
-      numericCode: '203'
-    },
-    {
-      name: 'Côte d\'Ivoire',
-      alpha2Code: 'CI',
-      alpha3Code: 'CIV',
-      numericCode: '384'
-    },
-    {
-      name: 'Denmark',
-      alpha2Code: 'DK',
-      alpha3Code: 'DNK',
-      numericCode: '208'
-    },
-    {
-      name: 'Djibouti',
-      alpha2Code: 'DJ',
-      alpha3Code: 'DJI',
-      numericCode: '262'
-    },
-    {
-      name: 'Dominica',
-      alpha2Code: 'DM',
-      alpha3Code: 'DMA',
-      numericCode: '212'
-    },
-    {
-      name: 'Dominican Republic',
-      alpha2Code: 'DO',
-      alpha3Code: 'DOM',
-      numericCode: '214'
-    },
-    {
-      name: 'Ecuador',
-      alpha2Code: 'EC',
-      alpha3Code: 'ECU',
-      numericCode: '218'
-    },
-    {
-      name: 'Egypt',
-      alpha2Code: 'EG',
-      alpha3Code: 'EGY',
-      numericCode: '818'
-    },
-    {
-      name: 'El Salvador',
-      alpha2Code: 'SV',
-      alpha3Code: 'SLV',
-      numericCode: '222'
-    },
-    {
-      name: 'Equatorial Guinea',
-      alpha2Code: 'GQ',
-      alpha3Code: 'GNQ',
-      numericCode: '226'
-    },
-    {
-      name: 'Eritrea',
-      alpha2Code: 'ER',
-      alpha3Code: 'ERI',
-      numericCode: '232'
-    },
-    {
-      name: 'Estonia',
-      alpha2Code: 'EE',
-      alpha3Code: 'EST',
-      numericCode: '233'
-    },
-    {
-      name: 'Eswatini',
-      alpha2Code: 'SZ',
-      alpha3Code: 'SWZ',
-      numericCode: '748'
-    },
-    {
-      name: 'Ethiopia',
-      alpha2Code: 'ET',
-      alpha3Code: 'ETH',
-      numericCode: '231'
-    },
-    {
-      name: 'Fiji',
-      alpha2Code: 'FJ',
-      alpha3Code: 'FJI',
-      numericCode: '242'
-    },
-    {
-      name: 'Finland',
-      alpha2Code: 'FI',
-      alpha3Code: 'FIN',
-      numericCode: '246'
-    },
-    {
-      name: 'France',
-      alpha2Code: 'FR',
-      alpha3Code: 'FRA',
-      numericCode: '250'
-    },
-    {
-      name: 'Gabon',
-      alpha2Code: 'GA',
-      alpha3Code: 'GAB',
-      numericCode: '266'
-    },
-    {
-      name: 'Gambia',
-      alpha2Code: 'GM',
-      alpha3Code: 'GMB',
-      numericCode: '270'
-    },
-    {
-      name: 'Georgia',
-      alpha2Code: 'GE',
-      alpha3Code: 'GEO',
-      numericCode: '268'
-    },
-    {
-      name: 'Germany',
-      alpha2Code: 'DE',
-      alpha3Code: 'DEU',
-      numericCode: '276'
-    },
-    {
-      name: 'Ghana',
-      alpha2Code: 'GH',
-      alpha3Code: 'GHA',
-      numericCode: '288'
-    },
-    {
-      name: 'Greece',
-      alpha2Code: 'GR',
-      alpha3Code: 'GRC',
-      numericCode: '300'
-    },
-    {
-      name: 'Greenland',
-      alpha2Code: 'GL',
-      alpha3Code: 'GRL',
-      numericCode: '304'
-    },
-    {
-      name: 'Guadeloupe',
-      alpha2Code: 'GP',
-      alpha3Code: 'GLP',
-      numericCode: '312'
-    },
-    {
-      name: 'Grenada',
-      alpha2Code: 'GD',
-      alpha3Code: 'GRD',
-      numericCode: '308'
-    },
-    {
-      name: 'Guatemala',
-      alpha2Code: 'GT',
-      alpha3Code: 'GTM',
-      numericCode: '320'
-    },
-    {
-      name: 'Guinea',
-      alpha2Code: 'GN',
-      alpha3Code: 'GIN',
-      numericCode: '324'
-    },
-    {
-      name: 'Guinea-Bissau',
-      alpha2Code: 'GW',
-      alpha3Code: 'GNB',
-      numericCode: '624'
-    },
-    {
-      name: 'Guyana',
-      alpha2Code: 'GY',
-      alpha3Code: 'GUY',
-      numericCode: '328'
-    },
-    {
-      name: 'Haiti',
-      alpha2Code: 'HT',
-      alpha3Code: 'HTI',
-      numericCode: '332'
-    },
-    {
-      name: 'Honduras',
-      alpha2Code: 'HN',
-      alpha3Code: 'HND',
-      numericCode: '340'
-    },
-    {
-      name: 'Hong Kong',
-      alpha2Code: 'HK',
-      alpha3Code: 'HKG',
-      numericCode: '344'
-    },
-    {
-      name: 'Hungary',
-      alpha2Code: 'HU',
-      alpha3Code: 'HUN',
-      numericCode: '348'
-    },
-    {
-      name: 'Iceland',
-      alpha2Code: 'IS',
-      alpha3Code: 'ISL',
-      numericCode: '352'
-    },
-    {
-      name: 'India',
-      alpha2Code: 'IN',
-      alpha3Code: 'IND',
-      numericCode: '356'
-    },
-    {
-      name: 'Indonesia',
-      alpha2Code: 'ID',
-      alpha3Code: 'IDN',
-      numericCode: '360'
-    },
-    {
-      name: 'Iran',
-      alpha2Code: 'IR',
-      alpha3Code: 'IRN',
-      numericCode: '364'
-    },
-    {
-      name: 'Iraq',
-      alpha2Code: 'IQ',
-      alpha3Code: 'IRQ',
-      numericCode: '368'
-    },
-    {
-      name: 'Ireland',
-      alpha2Code: 'IE',
-      alpha3Code: 'IRL',
-      numericCode: '372'
-    },
-    {
-      name: 'Israel',
-      alpha2Code: 'IL',
-      alpha3Code: 'ISR',
-      numericCode: '376'
-    },
-    {
-      name: 'Italy',
-      alpha2Code: 'IT',
-      alpha3Code: 'ITA',
-      numericCode: '380'
-    },
-    {
-      name: 'Jamaica',
-      alpha2Code: 'JM',
-      alpha3Code: 'JAM',
-      numericCode: '388'
-    },
-    {
-      name: 'Japan',
-      alpha2Code: 'JP',
-      alpha3Code: 'JPN',
-      numericCode: '392'
-    },
-    {
-      name: 'Jersey',
-      alpha2Code: 'JE',
-      alpha3Code: 'JEY',
-      numericCode: '832'
-    },
-    {
-      name: 'Jordan',
-      alpha2Code: 'JO',
-      alpha3Code: 'JOR',
-      numericCode: '400'
-    },
-    {
-      name: 'Kazakhstan',
-      alpha2Code: 'KZ',
-      alpha3Code: 'KAZ',
-      numericCode: '398'
-    },
-    {
-      name: 'Kenya',
-      alpha2Code: 'KE',
-      alpha3Code: 'KEN',
-      numericCode: '404'
-    },
-    {
-      name: 'Kiribati',
-      alpha2Code: 'KI',
-      alpha3Code: 'KIR',
-      numericCode: '296'
-    },
-    {
-      name: 'Korea (the Democratic People\'s Republic of)',
-      alpha2Code: 'KP',
-      alpha3Code: 'PRK',
-      numericCode: '408'
-    },
-    {
-      name: 'Korea (the Republic of)\t',
-      alpha2Code: 'KR',
-      alpha3Code: 'KOR',
-      numericCode: '410'
-    },
-    {
-      name: 'Kuwait',
-      alpha2Code: 'KW',
-      alpha3Code: 'KWT',
-      numericCode: '414'
-    },
-    {
-      name: 'Kyrgyzstan',
-      alpha2Code: 'KG',
-      alpha3Code: 'KGZ',
-      numericCode: '417'
-    },
-    {
-      name: 'Laos',
-      alpha2Code: 'LA',
-      alpha3Code: 'LAO',
-      numericCode: '418'
-    },
-    {
-      name: 'Latvia',
-      alpha2Code: 'LV',
-      alpha3Code: 'LVA',
-      numericCode: '428'
-    },
-    {
-      name: 'Lebanon',
-      alpha2Code: 'LB',
-      alpha3Code: 'LBN',
-      numericCode: '422'
-    },
-    {
-      name: 'Lesotho',
-      alpha2Code: 'LS',
-      alpha3Code: 'LSO',
-      numericCode: '426'
-    },
-    {
-      name: 'Liberia',
-      alpha2Code: 'LR',
-      alpha3Code: 'LBR',
-      numericCode: '430'
-    },
-    {
-      name: 'Libya',
-      alpha2Code: 'LY',
-      alpha3Code: 'LBY',
-      numericCode: '434'
-    },
-    {
-      name: 'Liechtenstein',
-      alpha2Code: 'LI',
-      alpha3Code: 'LIE',
-      numericCode: '438'
-    },
-    {
-      name: 'Lithuania',
-      alpha2Code: 'LT',
-      alpha3Code: 'LTU',
-      numericCode: '440'
-    },
-    {
-      name: 'Luxembourg',
-      alpha2Code: 'LU',
-      alpha3Code: 'LUX',
-      numericCode: '442'
-    },
-    {
-      name: 'Macao',
-      alpha2Code: 'MO',
-      alpha3Code: 'MAC',
-      numericCode: '446'
-    },
-    {
-      name: 'Madagascar',
-      alpha2Code: 'MG',
-      alpha3Code: 'MDG',
-      numericCode: '450'
-    },
-    {
-      name: 'Malawi',
-      alpha2Code: 'MW',
-      alpha3Code: 'MWI',
-      numericCode: '454'
-    },
-    {
-      name: 'Malaysia',
-      alpha2Code: 'MY',
-      alpha3Code: 'MYS',
-      numericCode: '458'
-    },
-    {
-      name: 'Maldives',
-      alpha2Code: 'MV',
-      alpha3Code: 'MDV',
-      numericCode: '462'
-    },
-    {
-      name: 'Mali',
-      alpha2Code: 'ML',
-      alpha3Code: 'MLI',
-      numericCode: '466'
-    },
-    {
-      name: 'Malta',
-      alpha2Code: 'MT',
-      alpha3Code: 'MLT',
-      numericCode: '470'
-    },
-    {
-      name: 'Mauritania',
-      alpha2Code: 'MR',
-      alpha3Code: 'MRT',
-      numericCode: '478'
-    },
-    {
-      name: 'Mauritius',
-      alpha2Code: 'MU',
-      alpha3Code: 'MUS',
-      numericCode: '480'
-    },
-    {
-      name: 'Mexico',
-      alpha2Code: 'MX',
-      alpha3Code: 'MEX',
-      numericCode: '484'
-    },
-    {
-      name: 'Moldova',
-      alpha2Code: 'MD',
-      alpha3Code: 'MDA',
-      numericCode: '498'
-    },
-    {
-      name: 'Monaco',
-      alpha2Code: 'MC',
-      alpha3Code: 'MCO',
-      numericCode: '492'
-    },
-    {
-      name: 'Mongolia',
-      alpha2Code: 'MN',
-      alpha3Code: 'MNG',
-      numericCode: '496'
-    },
-    {
-      name: 'Montenegro',
-      alpha2Code: 'ME',
-      alpha3Code: 'MNE',
-      numericCode: '499'
-    },
-    {
-      name: 'Morocco',
-      alpha2Code: 'MA',
-      alpha3Code: 'MAR',
-      numericCode: '504'
-    },
-    {
-      name: 'Mozambique',
-      alpha2Code: 'MZ',
-      alpha3Code: 'MOZ',
-      numericCode: '508'
-    },
-    {
-      name: 'Myanmar',
-      alpha2Code: 'MM',
-      alpha3Code: 'MMR',
-      numericCode: '104'
-    },
-    {
-      name: 'Namibia',
-      alpha2Code: 'NA',
-      alpha3Code: 'NAM',
-      numericCode: '516'
-    },
-    {
-      name: 'Nauru',
-      alpha2Code: 'NR',
-      alpha3Code: 'NRU',
-      numericCode: '520'
-    },
-    {
-      name: 'Nepal',
-      alpha2Code: 'NP',
-      alpha3Code: 'NPL',
-      numericCode: '524'
-    },
-    {
-      name: 'Netherlands',
-      alpha2Code: 'NL',
-      alpha3Code: 'NLD',
-      numericCode: '528'
-    },
-    {
-      name: 'New Caledonia',
-      alpha2Code: 'NC',
-      alpha3Code: 'NCL',
-      numericCode: '540'
-    },
-    {
-      name: 'New Zealand',
-      alpha2Code: 'NZ',
-      alpha3Code: 'NZL',
-      numericCode: '554'
-    },
-    {
-      name: 'Nicaragua',
-      alpha2Code: 'NI',
-      alpha3Code: 'NIC',
-      numericCode: '558'
-    },
-    {
-      name: 'Niger',
-      alpha2Code: 'NE',
-      alpha3Code: 'NER',
-      numericCode: '562'
-    },
-    {
-      name: 'Nigeria',
-      alpha2Code: 'NG',
-      alpha3Code: 'NGA',
-      numericCode: '566'
-    },
-    {
-      name: 'Norway',
-      alpha2Code: 'NO',
-      alpha3Code: 'NOR',
-      numericCode: '578'
-    },
-    {
-      name: 'Oman',
-      alpha2Code: 'OM',
-      alpha3Code: 'OMN',
-      numericCode: '512'
-    },
-    {
-      name: 'Pakistan',
-      alpha2Code: 'PK',
-      alpha3Code: 'PAK',
-      numericCode: '586'
-    },
-    {
-      name: 'Palau',
-      alpha2Code: 'PW',
-      alpha3Code: 'PLW',
-      numericCode: '585'
-    },
-    {
-      name: 'Palestine',
-      alpha2Code: 'PS',
-      alpha3Code: 'PSE',
-      numericCode: '275'
-    },
-    {
-      name: 'Panama',
-      alpha2Code: 'PA',
-      alpha3Code: 'PAN',
-      numericCode: '591'
-    },
-    {
-      name: 'Papua New Guinea',
-      alpha2Code: 'PG',
-      alpha3Code: 'PNG',
-      numericCode: '598'
-    },
-    {
-      name: 'Paraguay',
-      alpha2Code: 'PY',
-      alpha3Code: 'PRY',
-      numericCode: '600'
-    },
-    {
-      name: 'Peru',
-      alpha2Code: 'PE',
-      alpha3Code: 'PER',
-      numericCode: '604'
-    },
-    {
-      name: 'Philippines',
-      alpha2Code: 'PH',
-      alpha3Code: 'PHL',
-      numericCode: '608'
-    },
-    {
-      name: 'Poland',
-      alpha2Code: 'PL',
-      alpha3Code: 'POL',
-      numericCode: '616'
-    },
-    {
-      name: 'Portugal',
-      alpha2Code: 'PT',
-      alpha3Code: 'PRT',
-      numericCode: '620'
-    },
-    {
-      name: 'Puerto Rico',
-      alpha2Code: 'PR',
-      alpha3Code: 'PRI',
-      numericCode: '630'
-    },
-    {
-      name: 'Qatar',
-      alpha2Code: 'QA',
-      alpha3Code: 'QAT',
-      numericCode: '634'
-    },
-    {
-      name: 'Republic of North Macedonia',
-      alpha2Code: 'MK',
-      alpha3Code: 'MKD',
-      numericCode: '807'
-    },
-    {
-      name: 'Romania',
-      alpha2Code: 'RO',
-      alpha3Code: 'ROU',
-      numericCode: '642'
-    },
-    {
-      name: 'Russian Federation (the)',
-      alpha2Code: 'RU',
-      alpha3Code: 'RUS',
-      numericCode: '643'
-    },
-    {
-      name: 'Rwanda',
-      alpha2Code: 'RW',
-      alpha3Code: 'RWA',
-      numericCode: '646'
-    },
-    {
-      name: 'Saint Kitts and Nevis',
-      alpha2Code: 'KN',
-      alpha3Code: 'KNA',
-      numericCode: '659'
-    },
-    {
-      name: 'Saint Lucia',
-      alpha2Code: 'LC',
-      alpha3Code: 'LCA',
-      numericCode: '662'
-    },
-    {
-      name: 'Saint Vincent and the Grenadines',
-      alpha2Code: 'VC',
-      alpha3Code: 'VCT',
-      numericCode: '670'
-    },
-    {
-      name: 'Samoa',
-      alpha2Code: 'WS',
-      alpha3Code: 'WSM',
-      numericCode: '882'
-    },
-    {
-      name: 'San Marino',
-      alpha2Code: 'SM',
-      alpha3Code: 'SMR',
-      numericCode: '674'
-    },
-    {
-      name: 'Sao Tome and Principe',
-      alpha2Code: 'ST',
-      alpha3Code: 'STP',
-      numericCode: '678'
-    },
-    {
-      name: 'Saudi Arabia',
-      alpha2Code: 'SA',
-      alpha3Code: 'SAU',
-      numericCode: '682'
-    },
-    {
-      name: 'Senegal',
-      alpha2Code: 'SN',
-      alpha3Code: 'SEN',
-      numericCode: '686'
-    },
-    {
-      name: 'Serbia',
-      alpha2Code: 'RS',
-      alpha3Code: 'SRB',
-      numericCode: '688'
-    },
-    {
-      name: 'Seychelles',
-      alpha2Code: 'SC',
-      alpha3Code: 'SYC',
-      numericCode: '690'
-    },
-    {
-      name: 'Sierra Leone',
-      alpha2Code: 'SL',
-      alpha3Code: 'SLE',
-      numericCode: '694'
-    },
-    {
-      name: 'Singapore',
-      alpha2Code: 'SG',
-      alpha3Code: 'SGP',
-      numericCode: '702'
-    },
-    {
-      name: 'Slovakia',
-      alpha2Code: 'SK',
-      alpha3Code: 'SVK',
-      numericCode: '703'
-    },
-    {
-      name: 'Slovenia',
-      alpha2Code: 'SI',
-      alpha3Code: 'SVN',
-      numericCode: '705'
-    },
-    {
-      name: 'Solomon Islands',
-      alpha2Code: 'SB',
-      alpha3Code: 'SLB',
-      numericCode: '090'
-    },
-    {
-      name: 'Somalia',
-      alpha2Code: 'SO',
-      alpha3Code: 'SOM',
-      numericCode: '706'
-    },
-    {
-      name: 'South Africa',
-      alpha2Code: 'ZA',
-      alpha3Code: 'ZAF',
-      numericCode: '710'
-    },
-    {
-      name: 'South Sudan',
-      alpha2Code: 'SS',
-      alpha3Code: 'SSD',
-      numericCode: '728'
-    },
-    {
-      name: 'Spain',
-      alpha2Code: 'ES',
-      alpha3Code: 'ESP',
-      numericCode: '724'
-    },
-    {
-      name: 'Sri Lanka',
-      alpha2Code: 'LK',
-      alpha3Code: 'LKA',
-      numericCode: '144'
-    },
-    {
-      name: 'Sudan',
-      alpha2Code: 'SD',
-      alpha3Code: 'SDN',
-      numericCode: '729'
-    },
-    {
-      name: 'Suriname',
-      alpha2Code: 'SR',
-      alpha3Code: 'SUR',
-      numericCode: '740'
-    },
-    {
-      name: 'Sweden',
-      alpha2Code: 'SE',
-      alpha3Code: 'SWE',
-      numericCode: '752'
-    },
-    {
-      name: 'Switzerland',
-      alpha2Code: 'CH',
-      alpha3Code: 'CHE',
-      numericCode: '756'
-    },
-    {
-      name: 'Syrian Arab Republic',
-      alpha2Code: 'SY',
-      alpha3Code: 'SYR',
-      numericCode: '760'
-    },
-    {
-      name: 'Taiwan',
-      alpha2Code: 'TW',
-      alpha3Code: 'TWN',
-      numericCode: '158'
-    },
-    {
-      name: 'Tajikistan',
-      alpha2Code: 'TJ',
-      alpha3Code: 'TJK',
-      numericCode: '762'
-    },
-    {
-      name: 'Tanzania',
-      alpha2Code: 'TZ',
-      alpha3Code: 'TZA',
-      numericCode: '834'
-    },
-    {
-      name: 'Thailand',
-      alpha2Code: 'TH',
-      alpha3Code: 'THA',
-      numericCode: '764'
-    },
-    {
-      name: 'Timor-Leste',
-      alpha2Code: 'TL',
-      alpha3Code: 'TLS',
-      numericCode: '626'
-    },
-    {
-      name: 'Togo',
-      alpha2Code: 'TG',
-      alpha3Code: 'TGO',
-      numericCode: '768'
-    },
-    {
-      name: 'Tonga',
-      alpha2Code: 'TO',
-      alpha3Code: 'TON',
-      numericCode: '776'
-    },
-    {
-      name: 'Trinidad and Tobago',
-      alpha2Code: 'TT',
-      alpha3Code: 'TTO',
-      numericCode: '780'
-    },
-    {
-      name: 'Tunisia',
-      alpha2Code: 'TN',
-      alpha3Code: 'TUN',
-      numericCode: '788'
-    },
-    {
-      name: 'Turkey',
-      alpha2Code: 'TR',
-      alpha3Code: 'TUR',
-      numericCode: '792'
-    },
-    {
-      name: 'Turkmenistan',
-      alpha2Code: 'TM',
-      alpha3Code: 'TKM',
-      numericCode: '795'
-    },
-    {
-      name: 'Tuvalu',
-      alpha2Code: 'TV',
-      alpha3Code: 'TUV',
-      numericCode: '798'
-    },
-    {
-      name: 'Uganda',
-      alpha2Code: 'UG',
-      alpha3Code: 'UGA',
-      numericCode: '800'
-    },
-    {
-      name: 'Ukraine',
-      alpha2Code: 'UA',
-      alpha3Code: 'UKR',
-      numericCode: '804'
-    },
-    {
-      name: 'United Arab Emirates',
-      alpha2Code: 'AE',
-      alpha3Code: 'ARE',
-      numericCode: '784'
-    },
-    {
-      name: 'United Kingdom',
-      alpha2Code: 'GB',
-      alpha3Code: 'GBR',
-      numericCode: '826'
-    },
-    {
-      name: 'United States of America',
-      alpha2Code: 'US',
-      alpha3Code: 'USA',
-      numericCode: '840'
-    },
-    {
-      name: 'Uruguay',
-      alpha2Code: 'UY',
-      alpha3Code: 'URY',
-      numericCode: '858'
-    },
-    {
-      name: 'Uzbekistan',
-      alpha2Code: 'UZ',
-      alpha3Code: 'UZB',
-      numericCode: '860'
-    },
-    {
-      name: 'Vanuatu',
-      alpha2Code: 'VU',
-      alpha3Code: 'VUT',
-      numericCode: '548'
-    },
-    {
-      name: 'Venezuela',
-      alpha2Code: 'VE',
-      alpha3Code: 'VEN',
-      numericCode: '862'
-    },
-    {
-      name: 'Vietnam',
-      alpha2Code: 'VN',
-      alpha3Code: 'VNM',
-      numericCode: '704'
-    },
-    {
-      name: 'Yemen',
-      alpha2Code: 'YE',
-      alpha3Code: 'YEM',
-      numericCode: '887'
-    },
-    {
-      name: 'Zambia',
-      alpha2Code: 'ZM',
-      alpha3Code: 'ZMB',
-      numericCode: '894'
-    },
-    {
-      name: 'Zimbabwe',
-      alpha2Code: 'ZW',
-      alpha3Code: 'ZWE',
-      numericCode: '716'
-    }
-  ]
-;
+export const COUNTRIES_DB: Country[] = [
+  {
+    name: 'Afghanistan',
+    alpha2Code: 'AF',
+    alpha3Code: 'AFG',
+    numericCode: '004'
+  },
+  {
+    name: 'Albania',
+    alpha2Code: 'AL',
+    alpha3Code: 'ALB',
+    numericCode: '008'
+  },
+  {
+    name: 'Algeria',
+    alpha2Code: 'DZ',
+    alpha3Code: 'DZA',
+    numericCode: '012'
+  },
+  {
+    name: 'American Samoa',
+    alpha2Code: 'AS',
+    alpha3Code: 'ASM',
+    numericCode: '016'
+  },
+  {
+    name: 'Andorra',
+    alpha2Code: 'AD',
+    alpha3Code: 'AND',
+    numericCode: '020'
+  },
+  {
+    name: 'Angola',
+    alpha2Code: 'AO',
+    alpha3Code: 'AGO',
+    numericCode: '024'
+  },
+  {
+    name: 'Antigua and Barbuda',
+    alpha2Code: 'AG',
+    alpha3Code: 'ATG',
+    numericCode: '028'
+  },
+  {
+    name: 'Argentina',
+    alpha2Code: 'AR',
+    alpha3Code: 'ARG',
+    numericCode: '032'
+  },
+  {
+    name: 'Armenia',
+    alpha2Code: 'AM',
+    alpha3Code: 'ARM',
+    numericCode: '051'
+  },
+  {
+    name: 'Australia',
+    alpha2Code: 'AU',
+    alpha3Code: 'AUS',
+    numericCode: '036'
+  },
+  {
+    name: 'Austria',
+    alpha2Code: 'AT',
+    alpha3Code: 'AUT',
+    numericCode: '040'
+  },
+  {
+    name: 'Azerbaijan',
+    alpha2Code: 'AZ',
+    alpha3Code: 'AZE',
+    numericCode: '031'
+  },
+  {
+    name: 'Bahamas',
+    alpha2Code: 'BS',
+    alpha3Code: 'BHS',
+    numericCode: '044'
+  },
+  {
+    name: 'Bahrain',
+    alpha2Code: 'BH',
+    alpha3Code: 'BHR',
+    numericCode: '048'
+  },
+  {
+    name: 'Bangladesh',
+    alpha2Code: 'BD',
+    alpha3Code: 'BGD',
+    numericCode: '050'
+  },
+  {
+    name: 'Barbados',
+    alpha2Code: 'BB',
+    alpha3Code: 'BRB',
+    numericCode: '052'
+  },
+  {
+    name: 'Belarus',
+    alpha2Code: 'BY',
+    alpha3Code: 'BLR',
+    numericCode: '112'
+  },
+  {
+    name: 'Belgium',
+    alpha2Code: 'BE',
+    alpha3Code: 'BEL',
+    numericCode: '056'
+  },
+  {
+    name: 'Belize',
+    alpha2Code: 'BZ',
+    alpha3Code: 'BLZ',
+    numericCode: '084'
+  },
+  {
+    name: 'Benin',
+    alpha2Code: 'BJ',
+    alpha3Code: 'BEN',
+    numericCode: '204'
+  },
+  {
+    name: 'Bermuda',
+    alpha2Code: 'BM',
+    alpha3Code: 'BMU',
+    numericCode: '060'
+  },
+  {
+    name: 'Bhutan',
+    alpha2Code: 'BT',
+    alpha3Code: 'BTN',
+    numericCode: '064'
+  },
+  {
+    name: 'Bolivia',
+    alpha2Code: 'BO',
+    alpha3Code: 'BOL',
+    numericCode: '068'
+  },
+  {
+    name: 'Bonaire, Sint Eustatius and Saba',
+    alpha2Code: 'BQ',
+    alpha3Code: 'BES',
+    numericCode: '535'
+  },
+  {
+    name: 'Bosnia and Herzegovina',
+    alpha2Code: 'BA',
+    alpha3Code: 'BIH',
+    numericCode: '070'
+  },
+  {
+    name: 'Botswana',
+    alpha2Code: 'BW',
+    alpha3Code: 'BWA',
+    numericCode: '072'
+  },
+  {
+    name: 'Bouvet Island',
+    alpha2Code: 'BV',
+    alpha3Code: 'BVT',
+    numericCode: '074'
+  },
+  {
+    name: 'Brazil',
+    alpha2Code: 'BR',
+    alpha3Code: 'BRA',
+    numericCode: '076'
+  },
+  {
+    name: 'Brunei',
+    alpha2Code: 'BN',
+    alpha3Code: 'BRN',
+    numericCode: '096'
+  },
+  {
+    name: 'Bulgaria',
+    alpha2Code: 'BG',
+    alpha3Code: 'BGR',
+    numericCode: '100'
+  },
+  {
+    name: 'Burkina Faso',
+    alpha2Code: 'BF',
+    alpha3Code: 'BFA',
+    numericCode: '854'
+  },
+  {
+    name: 'Burundi',
+    alpha2Code: 'BI',
+    alpha3Code: 'BDI',
+    numericCode: '108'
+  },
+  {
+    name: 'Cabo Verde',
+    alpha2Code: 'CV',
+    alpha3Code: 'CPV',
+    numericCode: '132'
+  },
+  {
+    name: 'Cambodia',
+    alpha2Code: 'KH',
+    alpha3Code: 'KHM',
+    numericCode: '116'
+  },
+  {
+    name: 'Cameroon',
+    alpha2Code: 'CM',
+    alpha3Code: 'CMR',
+    numericCode: '120'
+  },
+  {
+    name: 'Canada',
+    alpha2Code: 'CA',
+    alpha3Code: 'CAN',
+    numericCode: '124'
+  },
+  {
+    name: 'Central African Republic',
+    alpha2Code: 'CF',
+    alpha3Code: 'CAF',
+    numericCode: '140'
+  },
+  {
+    name: 'Chad',
+    alpha2Code: 'TD',
+    alpha3Code: 'TCD',
+    numericCode: '148'
+  },
+  {
+    name: 'Chile',
+    alpha2Code: 'CL',
+    alpha3Code: 'CHL',
+    numericCode: '152'
+  },
+  {
+    name: 'China',
+    alpha2Code: 'CN',
+    alpha3Code: 'CHN',
+    numericCode: '156'
+  },
+  {
+    name: 'Colombia',
+    alpha2Code: 'CO',
+    alpha3Code: 'COL',
+    numericCode: '170'
+  },
+  {
+    name: 'Congo (Democratic Republic of the)',
+    alpha2Code: 'CD',
+    alpha3Code: 'COD',
+    numericCode: '180'
+  },
+  {
+    name: 'Congo (Republic of the)',
+    alpha2Code: 'CG',
+    alpha3Code: 'COG',
+    numericCode: '178'
+  },
+  {
+    name: 'Costa Rica',
+    alpha2Code: 'CR',
+    alpha3Code: 'CRI',
+    numericCode: '188'
+  },
+  {
+    name: 'Croatia',
+    alpha2Code: 'HR',
+    alpha3Code: 'HRV',
+    numericCode: '191'
+  },
+  {
+    name: 'Cuba',
+    alpha2Code: 'CU',
+    alpha3Code: 'CUB',
+    numericCode: '192'
+  },
+  {
+    name: 'Cyprus',
+    alpha2Code: 'CY',
+    alpha3Code: 'CYP',
+    numericCode: '196'
+  },
+  {
+    name: 'Czechia',
+    alpha2Code: 'CZ',
+    alpha3Code: 'CZE',
+    numericCode: '203'
+  },
+  {
+    name: "Côte d'Ivoire",
+    alpha2Code: 'CI',
+    alpha3Code: 'CIV',
+    numericCode: '384'
+  },
+  {
+    name: 'Denmark',
+    alpha2Code: 'DK',
+    alpha3Code: 'DNK',
+    numericCode: '208'
+  },
+  {
+    name: 'Djibouti',
+    alpha2Code: 'DJ',
+    alpha3Code: 'DJI',
+    numericCode: '262'
+  },
+  {
+    name: 'Dominica',
+    alpha2Code: 'DM',
+    alpha3Code: 'DMA',
+    numericCode: '212'
+  },
+  {
+    name: 'Dominican Republic',
+    alpha2Code: 'DO',
+    alpha3Code: 'DOM',
+    numericCode: '214'
+  },
+  {
+    name: 'Ecuador',
+    alpha2Code: 'EC',
+    alpha3Code: 'ECU',
+    numericCode: '218'
+  },
+  {
+    name: 'Egypt',
+    alpha2Code: 'EG',
+    alpha3Code: 'EGY',
+    numericCode: '818'
+  },
+  {
+    name: 'El Salvador',
+    alpha2Code: 'SV',
+    alpha3Code: 'SLV',
+    numericCode: '222'
+  },
+  {
+    name: 'Equatorial Guinea',
+    alpha2Code: 'GQ',
+    alpha3Code: 'GNQ',
+    numericCode: '226'
+  },
+  {
+    name: 'Eritrea',
+    alpha2Code: 'ER',
+    alpha3Code: 'ERI',
+    numericCode: '232'
+  },
+  {
+    name: 'Estonia',
+    alpha2Code: 'EE',
+    alpha3Code: 'EST',
+    numericCode: '233'
+  },
+  {
+    name: 'Eswatini',
+    alpha2Code: 'SZ',
+    alpha3Code: 'SWZ',
+    numericCode: '748'
+  },
+  {
+    name: 'Ethiopia',
+    alpha2Code: 'ET',
+    alpha3Code: 'ETH',
+    numericCode: '231'
+  },
+  {
+    name: 'Fiji',
+    alpha2Code: 'FJ',
+    alpha3Code: 'FJI',
+    numericCode: '242'
+  },
+  {
+    name: 'Finland',
+    alpha2Code: 'FI',
+    alpha3Code: 'FIN',
+    numericCode: '246'
+  },
+  {
+    name: 'France',
+    alpha2Code: 'FR',
+    alpha3Code: 'FRA',
+    numericCode: '250'
+  },
+  {
+    name: 'Gabon',
+    alpha2Code: 'GA',
+    alpha3Code: 'GAB',
+    numericCode: '266'
+  },
+  {
+    name: 'Gambia',
+    alpha2Code: 'GM',
+    alpha3Code: 'GMB',
+    numericCode: '270'
+  },
+  {
+    name: 'Georgia',
+    alpha2Code: 'GE',
+    alpha3Code: 'GEO',
+    numericCode: '268'
+  },
+  {
+    name: 'Germany',
+    alpha2Code: 'DE',
+    alpha3Code: 'DEU',
+    numericCode: '276'
+  },
+  {
+    name: 'Ghana',
+    alpha2Code: 'GH',
+    alpha3Code: 'GHA',
+    numericCode: '288'
+  },
+  {
+    name: 'Greece',
+    alpha2Code: 'GR',
+    alpha3Code: 'GRC',
+    numericCode: '300'
+  },
+  {
+    name: 'Greenland',
+    alpha2Code: 'GL',
+    alpha3Code: 'GRL',
+    numericCode: '304'
+  },
+  {
+    name: 'Guadeloupe',
+    alpha2Code: 'GP',
+    alpha3Code: 'GLP',
+    numericCode: '312'
+  },
+  {
+    name: 'Grenada',
+    alpha2Code: 'GD',
+    alpha3Code: 'GRD',
+    numericCode: '308'
+  },
+  {
+    name: 'Guatemala',
+    alpha2Code: 'GT',
+    alpha3Code: 'GTM',
+    numericCode: '320'
+  },
+  {
+    name: 'Guinea',
+    alpha2Code: 'GN',
+    alpha3Code: 'GIN',
+    numericCode: '324'
+  },
+  {
+    name: 'Guinea-Bissau',
+    alpha2Code: 'GW',
+    alpha3Code: 'GNB',
+    numericCode: '624'
+  },
+  {
+    name: 'Guyana',
+    alpha2Code: 'GY',
+    alpha3Code: 'GUY',
+    numericCode: '328'
+  },
+  {
+    name: 'Haiti',
+    alpha2Code: 'HT',
+    alpha3Code: 'HTI',
+    numericCode: '332'
+  },
+  {
+    name: 'Honduras',
+    alpha2Code: 'HN',
+    alpha3Code: 'HND',
+    numericCode: '340'
+  },
+  {
+    name: 'Hong Kong',
+    alpha2Code: 'HK',
+    alpha3Code: 'HKG',
+    numericCode: '344'
+  },
+  {
+    name: 'Hungary',
+    alpha2Code: 'HU',
+    alpha3Code: 'HUN',
+    numericCode: '348'
+  },
+  {
+    name: 'Iceland',
+    alpha2Code: 'IS',
+    alpha3Code: 'ISL',
+    numericCode: '352'
+  },
+  {
+    name: 'India',
+    alpha2Code: 'IN',
+    alpha3Code: 'IND',
+    numericCode: '356'
+  },
+  {
+    name: 'Indonesia',
+    alpha2Code: 'ID',
+    alpha3Code: 'IDN',
+    numericCode: '360'
+  },
+  {
+    name: 'Iran',
+    alpha2Code: 'IR',
+    alpha3Code: 'IRN',
+    numericCode: '364'
+  },
+  {
+    name: 'Iraq',
+    alpha2Code: 'IQ',
+    alpha3Code: 'IRQ',
+    numericCode: '368'
+  },
+  {
+    name: 'Ireland',
+    alpha2Code: 'IE',
+    alpha3Code: 'IRL',
+    numericCode: '372'
+  },
+  {
+    name: 'Israel',
+    alpha2Code: 'IL',
+    alpha3Code: 'ISR',
+    numericCode: '376'
+  },
+  {
+    name: 'Italy',
+    alpha2Code: 'IT',
+    alpha3Code: 'ITA',
+    numericCode: '380'
+  },
+  {
+    name: 'Jamaica',
+    alpha2Code: 'JM',
+    alpha3Code: 'JAM',
+    numericCode: '388'
+  },
+  {
+    name: 'Japan',
+    alpha2Code: 'JP',
+    alpha3Code: 'JPN',
+    numericCode: '392'
+  },
+  {
+    name: 'Jersey',
+    alpha2Code: 'JE',
+    alpha3Code: 'JEY',
+    numericCode: '832'
+  },
+  {
+    name: 'Jordan',
+    alpha2Code: 'JO',
+    alpha3Code: 'JOR',
+    numericCode: '400'
+  },
+  {
+    name: 'Kazakhstan',
+    alpha2Code: 'KZ',
+    alpha3Code: 'KAZ',
+    numericCode: '398'
+  },
+  {
+    name: 'Kenya',
+    alpha2Code: 'KE',
+    alpha3Code: 'KEN',
+    numericCode: '404'
+  },
+  {
+    name: 'Kiribati',
+    alpha2Code: 'KI',
+    alpha3Code: 'KIR',
+    numericCode: '296'
+  },
+  {
+    name: "Korea (the Democratic People's Republic of)",
+    alpha2Code: 'KP',
+    alpha3Code: 'PRK',
+    numericCode: '408'
+  },
+  {
+    name: 'Korea (the Republic of)\t',
+    alpha2Code: 'KR',
+    alpha3Code: 'KOR',
+    numericCode: '410'
+  },
+  {
+    name: 'Kuwait',
+    alpha2Code: 'KW',
+    alpha3Code: 'KWT',
+    numericCode: '414'
+  },
+  {
+    name: 'Kyrgyzstan',
+    alpha2Code: 'KG',
+    alpha3Code: 'KGZ',
+    numericCode: '417'
+  },
+  {
+    name: 'Laos',
+    alpha2Code: 'LA',
+    alpha3Code: 'LAO',
+    numericCode: '418'
+  },
+  {
+    name: 'Latvia',
+    alpha2Code: 'LV',
+    alpha3Code: 'LVA',
+    numericCode: '428'
+  },
+  {
+    name: 'Lebanon',
+    alpha2Code: 'LB',
+    alpha3Code: 'LBN',
+    numericCode: '422'
+  },
+  {
+    name: 'Lesotho',
+    alpha2Code: 'LS',
+    alpha3Code: 'LSO',
+    numericCode: '426'
+  },
+  {
+    name: 'Liberia',
+    alpha2Code: 'LR',
+    alpha3Code: 'LBR',
+    numericCode: '430'
+  },
+  {
+    name: 'Libya',
+    alpha2Code: 'LY',
+    alpha3Code: 'LBY',
+    numericCode: '434'
+  },
+  {
+    name: 'Liechtenstein',
+    alpha2Code: 'LI',
+    alpha3Code: 'LIE',
+    numericCode: '438'
+  },
+  {
+    name: 'Lithuania',
+    alpha2Code: 'LT',
+    alpha3Code: 'LTU',
+    numericCode: '440'
+  },
+  {
+    name: 'Luxembourg',
+    alpha2Code: 'LU',
+    alpha3Code: 'LUX',
+    numericCode: '442'
+  },
+  {
+    name: 'Macao',
+    alpha2Code: 'MO',
+    alpha3Code: 'MAC',
+    numericCode: '446'
+  },
+  {
+    name: 'Madagascar',
+    alpha2Code: 'MG',
+    alpha3Code: 'MDG',
+    numericCode: '450'
+  },
+  {
+    name: 'Malawi',
+    alpha2Code: 'MW',
+    alpha3Code: 'MWI',
+    numericCode: '454'
+  },
+  {
+    name: 'Malaysia',
+    alpha2Code: 'MY',
+    alpha3Code: 'MYS',
+    numericCode: '458'
+  },
+  {
+    name: 'Maldives',
+    alpha2Code: 'MV',
+    alpha3Code: 'MDV',
+    numericCode: '462'
+  },
+  {
+    name: 'Mali',
+    alpha2Code: 'ML',
+    alpha3Code: 'MLI',
+    numericCode: '466'
+  },
+  {
+    name: 'Malta',
+    alpha2Code: 'MT',
+    alpha3Code: 'MLT',
+    numericCode: '470'
+  },
+  {
+    name: 'Mauritania',
+    alpha2Code: 'MR',
+    alpha3Code: 'MRT',
+    numericCode: '478'
+  },
+  {
+    name: 'Mauritius',
+    alpha2Code: 'MU',
+    alpha3Code: 'MUS',
+    numericCode: '480'
+  },
+  {
+    name: 'Mexico',
+    alpha2Code: 'MX',
+    alpha3Code: 'MEX',
+    numericCode: '484'
+  },
+  {
+    name: 'Moldova',
+    alpha2Code: 'MD',
+    alpha3Code: 'MDA',
+    numericCode: '498'
+  },
+  {
+    name: 'Monaco',
+    alpha2Code: 'MC',
+    alpha3Code: 'MCO',
+    numericCode: '492'
+  },
+  {
+    name: 'Mongolia',
+    alpha2Code: 'MN',
+    alpha3Code: 'MNG',
+    numericCode: '496'
+  },
+  {
+    name: 'Montenegro',
+    alpha2Code: 'ME',
+    alpha3Code: 'MNE',
+    numericCode: '499'
+  },
+  {
+    name: 'Morocco',
+    alpha2Code: 'MA',
+    alpha3Code: 'MAR',
+    numericCode: '504'
+  },
+  {
+    name: 'Mozambique',
+    alpha2Code: 'MZ',
+    alpha3Code: 'MOZ',
+    numericCode: '508'
+  },
+  {
+    name: 'Myanmar',
+    alpha2Code: 'MM',
+    alpha3Code: 'MMR',
+    numericCode: '104'
+  },
+  {
+    name: 'Namibia',
+    alpha2Code: 'NA',
+    alpha3Code: 'NAM',
+    numericCode: '516'
+  },
+  {
+    name: 'Nauru',
+    alpha2Code: 'NR',
+    alpha3Code: 'NRU',
+    numericCode: '520'
+  },
+  {
+    name: 'Nepal',
+    alpha2Code: 'NP',
+    alpha3Code: 'NPL',
+    numericCode: '524'
+  },
+  {
+    name: 'Netherlands',
+    alpha2Code: 'NL',
+    alpha3Code: 'NLD',
+    numericCode: '528'
+  },
+  {
+    name: 'New Caledonia',
+    alpha2Code: 'NC',
+    alpha3Code: 'NCL',
+    numericCode: '540'
+  },
+  {
+    name: 'New Zealand',
+    alpha2Code: 'NZ',
+    alpha3Code: 'NZL',
+    numericCode: '554'
+  },
+  {
+    name: 'Nicaragua',
+    alpha2Code: 'NI',
+    alpha3Code: 'NIC',
+    numericCode: '558'
+  },
+  {
+    name: 'Niger',
+    alpha2Code: 'NE',
+    alpha3Code: 'NER',
+    numericCode: '562'
+  },
+  {
+    name: 'Nigeria',
+    alpha2Code: 'NG',
+    alpha3Code: 'NGA',
+    numericCode: '566'
+  },
+  {
+    name: 'Norway',
+    alpha2Code: 'NO',
+    alpha3Code: 'NOR',
+    numericCode: '578'
+  },
+  {
+    name: 'Oman',
+    alpha2Code: 'OM',
+    alpha3Code: 'OMN',
+    numericCode: '512'
+  },
+  {
+    name: 'Pakistan',
+    alpha2Code: 'PK',
+    alpha3Code: 'PAK',
+    numericCode: '586'
+  },
+  {
+    name: 'Palau',
+    alpha2Code: 'PW',
+    alpha3Code: 'PLW',
+    numericCode: '585'
+  },
+  {
+    name: 'Palestine',
+    alpha2Code: 'PS',
+    alpha3Code: 'PSE',
+    numericCode: '275'
+  },
+  {
+    name: 'Panama',
+    alpha2Code: 'PA',
+    alpha3Code: 'PAN',
+    numericCode: '591'
+  },
+  {
+    name: 'Papua New Guinea',
+    alpha2Code: 'PG',
+    alpha3Code: 'PNG',
+    numericCode: '598'
+  },
+  {
+    name: 'Paraguay',
+    alpha2Code: 'PY',
+    alpha3Code: 'PRY',
+    numericCode: '600'
+  },
+  {
+    name: 'Peru',
+    alpha2Code: 'PE',
+    alpha3Code: 'PER',
+    numericCode: '604'
+  },
+  {
+    name: 'Philippines',
+    alpha2Code: 'PH',
+    alpha3Code: 'PHL',
+    numericCode: '608'
+  },
+  {
+    name: 'Poland',
+    alpha2Code: 'PL',
+    alpha3Code: 'POL',
+    numericCode: '616'
+  },
+  {
+    name: 'Portugal',
+    alpha2Code: 'PT',
+    alpha3Code: 'PRT',
+    numericCode: '620'
+  },
+  {
+    name: 'Puerto Rico',
+    alpha2Code: 'PR',
+    alpha3Code: 'PRI',
+    numericCode: '630'
+  },
+  {
+    name: 'Qatar',
+    alpha2Code: 'QA',
+    alpha3Code: 'QAT',
+    numericCode: '634'
+  },
+  {
+    name: 'Republic of North Macedonia',
+    alpha2Code: 'MK',
+    alpha3Code: 'MKD',
+    numericCode: '807'
+  },
+  {
+    name: 'Romania',
+    alpha2Code: 'RO',
+    alpha3Code: 'ROU',
+    numericCode: '642'
+  },
+  {
+    name: 'Russian Federation (the)',
+    alpha2Code: 'RU',
+    alpha3Code: 'RUS',
+    numericCode: '643'
+  },
+  {
+    name: 'Rwanda',
+    alpha2Code: 'RW',
+    alpha3Code: 'RWA',
+    numericCode: '646'
+  },
+  {
+    name: 'Saint Kitts and Nevis',
+    alpha2Code: 'KN',
+    alpha3Code: 'KNA',
+    numericCode: '659'
+  },
+  {
+    name: 'Saint Lucia',
+    alpha2Code: 'LC',
+    alpha3Code: 'LCA',
+    numericCode: '662'
+  },
+  {
+    name: 'Saint Vincent and the Grenadines',
+    alpha2Code: 'VC',
+    alpha3Code: 'VCT',
+    numericCode: '670'
+  },
+  {
+    name: 'Samoa',
+    alpha2Code: 'WS',
+    alpha3Code: 'WSM',
+    numericCode: '882'
+  },
+  {
+    name: 'San Marino',
+    alpha2Code: 'SM',
+    alpha3Code: 'SMR',
+    numericCode: '674'
+  },
+  {
+    name: 'Sao Tome and Principe',
+    alpha2Code: 'ST',
+    alpha3Code: 'STP',
+    numericCode: '678'
+  },
+  {
+    name: 'Saudi Arabia',
+    alpha2Code: 'SA',
+    alpha3Code: 'SAU',
+    numericCode: '682'
+  },
+  {
+    name: 'Senegal',
+    alpha2Code: 'SN',
+    alpha3Code: 'SEN',
+    numericCode: '686'
+  },
+  {
+    name: 'Serbia',
+    alpha2Code: 'RS',
+    alpha3Code: 'SRB',
+    numericCode: '688'
+  },
+  {
+    name: 'Seychelles',
+    alpha2Code: 'SC',
+    alpha3Code: 'SYC',
+    numericCode: '690'
+  },
+  {
+    name: 'Sierra Leone',
+    alpha2Code: 'SL',
+    alpha3Code: 'SLE',
+    numericCode: '694'
+  },
+  {
+    name: 'Singapore',
+    alpha2Code: 'SG',
+    alpha3Code: 'SGP',
+    numericCode: '702'
+  },
+  {
+    name: 'Slovakia',
+    alpha2Code: 'SK',
+    alpha3Code: 'SVK',
+    numericCode: '703'
+  },
+  {
+    name: 'Slovenia',
+    alpha2Code: 'SI',
+    alpha3Code: 'SVN',
+    numericCode: '705'
+  },
+  {
+    name: 'Solomon Islands',
+    alpha2Code: 'SB',
+    alpha3Code: 'SLB',
+    numericCode: '090'
+  },
+  {
+    name: 'Somalia',
+    alpha2Code: 'SO',
+    alpha3Code: 'SOM',
+    numericCode: '706'
+  },
+  {
+    name: 'South Africa',
+    alpha2Code: 'ZA',
+    alpha3Code: 'ZAF',
+    numericCode: '710'
+  },
+  {
+    name: 'South Sudan',
+    alpha2Code: 'SS',
+    alpha3Code: 'SSD',
+    numericCode: '728'
+  },
+  {
+    name: 'Spain',
+    alpha2Code: 'ES',
+    alpha3Code: 'ESP',
+    numericCode: '724'
+  },
+  {
+    name: 'Sri Lanka',
+    alpha2Code: 'LK',
+    alpha3Code: 'LKA',
+    numericCode: '144'
+  },
+  {
+    name: 'Sudan',
+    alpha2Code: 'SD',
+    alpha3Code: 'SDN',
+    numericCode: '729'
+  },
+  {
+    name: 'Suriname',
+    alpha2Code: 'SR',
+    alpha3Code: 'SUR',
+    numericCode: '740'
+  },
+  {
+    name: 'Sweden',
+    alpha2Code: 'SE',
+    alpha3Code: 'SWE',
+    numericCode: '752'
+  },
+  {
+    name: 'Switzerland',
+    alpha2Code: 'CH',
+    alpha3Code: 'CHE',
+    numericCode: '756'
+  },
+  {
+    name: 'Syrian Arab Republic',
+    alpha2Code: 'SY',
+    alpha3Code: 'SYR',
+    numericCode: '760'
+  },
+  {
+    name: 'Taiwan',
+    alpha2Code: 'TW',
+    alpha3Code: 'TWN',
+    numericCode: '158'
+  },
+  {
+    name: 'Tajikistan',
+    alpha2Code: 'TJ',
+    alpha3Code: 'TJK',
+    numericCode: '762'
+  },
+  {
+    name: 'Tanzania',
+    alpha2Code: 'TZ',
+    alpha3Code: 'TZA',
+    numericCode: '834'
+  },
+  {
+    name: 'Thailand',
+    alpha2Code: 'TH',
+    alpha3Code: 'THA',
+    numericCode: '764'
+  },
+  {
+    name: 'Timor-Leste',
+    alpha2Code: 'TL',
+    alpha3Code: 'TLS',
+    numericCode: '626'
+  },
+  {
+    name: 'Togo',
+    alpha2Code: 'TG',
+    alpha3Code: 'TGO',
+    numericCode: '768'
+  },
+  {
+    name: 'Tonga',
+    alpha2Code: 'TO',
+    alpha3Code: 'TON',
+    numericCode: '776'
+  },
+  {
+    name: 'Trinidad and Tobago',
+    alpha2Code: 'TT',
+    alpha3Code: 'TTO',
+    numericCode: '780'
+  },
+  {
+    name: 'Tunisia',
+    alpha2Code: 'TN',
+    alpha3Code: 'TUN',
+    numericCode: '788'
+  },
+  {
+    name: 'Turkey',
+    alpha2Code: 'TR',
+    alpha3Code: 'TUR',
+    numericCode: '792'
+  },
+  {
+    name: 'Turkmenistan',
+    alpha2Code: 'TM',
+    alpha3Code: 'TKM',
+    numericCode: '795'
+  },
+  {
+    name: 'Tuvalu',
+    alpha2Code: 'TV',
+    alpha3Code: 'TUV',
+    numericCode: '798'
+  },
+  {
+    name: 'Uganda',
+    alpha2Code: 'UG',
+    alpha3Code: 'UGA',
+    numericCode: '800'
+  },
+  {
+    name: 'Ukraine',
+    alpha2Code: 'UA',
+    alpha3Code: 'UKR',
+    numericCode: '804'
+  },
+  {
+    name: 'United Arab Emirates',
+    alpha2Code: 'AE',
+    alpha3Code: 'ARE',
+    numericCode: '784'
+  },
+  {
+    name: 'United Kingdom',
+    alpha2Code: 'GB',
+    alpha3Code: 'GBR',
+    numericCode: '826'
+  },
+  {
+    name: 'United States of America',
+    alpha2Code: 'US',
+    alpha3Code: 'USA',
+    numericCode: '840'
+  },
+  {
+    name: 'Uruguay',
+    alpha2Code: 'UY',
+    alpha3Code: 'URY',
+    numericCode: '858'
+  },
+  {
+    name: 'Uzbekistan',
+    alpha2Code: 'UZ',
+    alpha3Code: 'UZB',
+    numericCode: '860'
+  },
+  {
+    name: 'Vanuatu',
+    alpha2Code: 'VU',
+    alpha3Code: 'VUT',
+    numericCode: '548'
+  },
+  {
+    name: 'Venezuela',
+    alpha2Code: 'VE',
+    alpha3Code: 'VEN',
+    numericCode: '862'
+  },
+  {
+    name: 'Vietnam',
+    alpha2Code: 'VN',
+    alpha3Code: 'VNM',
+    numericCode: '704'
+  },
+  {
+    name: 'Yemen',
+    alpha2Code: 'YE',
+    alpha3Code: 'YEM',
+    numericCode: '887'
+  },
+  {
+    name: 'Zambia',
+    alpha2Code: 'ZM',
+    alpha3Code: 'ZMB',
+    numericCode: '894'
+  },
+  {
+    name: 'Zimbabwe',
+    alpha2Code: 'ZW',
+    alpha3Code: 'ZWE',
+    numericCode: '716'
+  }
+];

--- a/projects/angular-material-extensions/select-country/src/lib/i18n/es.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/i18n/es.ts
@@ -1,1218 +1,1222 @@
-import {Country} from '../mat-select-country.component';
+import { Country } from '../mat-select-country.component';
 
-export const COUNTRIES_DB_ES: Country[] =
-  [{
+export const COUNTRIES_DB_ES: Country[] = [
+  {
     name: 'Afganistán',
     alpha2Code: 'AF',
     alpha3Code: 'AFG',
     numericCode: '004'
   },
-    {
-      name: 'Albania',
-      alpha2Code: 'AL',
-      alpha3Code: 'ALB',
-      numericCode: '008'
-    },
-    {
-      name: 'Argelia',
-      alpha2Code: 'DZ',
-      alpha3Code: 'DZA',
-      numericCode: '012'
-    },
-    {
-      name: 'Samoa Americana',
-      alpha2Code: 'AS',
-      alpha3Code: 'ASM',
-      numericCode: '016'
-    },
-    {
-      name: 'Andorra',
-      alpha2Code: 'AD',
-      alpha3Code: 'Y',
-      numericCode: '020'
-    },
-    {
-      name: 'Angola',
-      alpha2Code: 'AO',
-      alpha3Code: 'AGO',
-      numericCode: '024'
-    },
-    {
-      name: 'Antigua y Barbuda',
-      alpha2Code: 'AG',
-      alpha3Code: 'ATG',
-      numericCode: '028'
-    },
-    {
-      name: 'Argentina',
-      alpha2Code: 'AR',
-      alpha3Code: 'ARG',
-      numericCode: '032'
-    },
-    {
-      name: 'Armenia',
-      alpha2Code: 'AM',
-      alpha3Code: 'ARM',
-      numericCode: '051'
-    },
-    {
-      name: 'Australia',
-      alpha2Code: 'AU',
-      alpha3Code: 'AUS',
-      numericCode: '036'
-    },
-    {
-      name: 'Austria',
-      alpha2Code: 'AT',
-      alpha3Code: 'AUT',
-      numericCode: '040'
-    },
-    {
-      name: 'Azerbaiyán',
-      alpha2Code: 'AZ',
-      alpha3Code: 'AZE',
-      numericCode: '031'
-    },
-    {
-      name: 'Bahamas',
-      alpha2Code: 'BS',
-      alpha3Code: 'BHS',
-      numericCode: '044'
-    },
-    {
-      name: 'Bahrein',
-      alpha2Code: 'BH',
-      alpha3Code: 'BHR',
-      numericCode: '048'
-    },
-    {
-      name: 'Bangladesh',
-      alpha2Code: 'BD',
-      alpha3Code: 'BGD',
-      numericCode: '050'
-    },
-    {
-      name: 'Barbados',
-      alpha2Code: 'BB',
-      alpha3Code: 'BRB',
-      numericCode: '052'
-    },
-    {
-      name: 'Bielorrusia',
-      alpha2Code: 'POR',
-      alpha3Code: 'BLR',
-      numericCode: '112'
-    },
-    {
-      name: 'Bélgica',
-      alpha2Code: 'BE',
-      alpha3Code: 'BEL',
-      numericCode: '056'
-    },
-    {
-      name: 'Belice',
-      alpha2Code: 'BZ',
-      alpha3Code: 'BLZ',
-      numericCode: '084'
-    },
-    {
-      name: 'Benin',
-      alpha2Code: 'BJ',
-      alpha3Code: 'BEN',
-      numericCode: '204'
-    },
-    {
-      name: 'Bermudas',
-      alpha2Code: 'BM',
-      alpha3Code: 'BMU',
-      numericCode: '060'
-    },
-    {
-      name: 'Bután',
-      alpha2Code: 'BT',
-      alpha3Code: 'BTN',
-      numericCode: '064'
-    },
-    {
-      name: 'Bolivia',
-      alpha2Code: 'BO',
-      alpha3Code: 'BOL',
-      numericCode: '068'
-    },
-    {
-      name: 'Bonaire, Sint Eustatius and Saba',
-      alpha2Code: 'BQ',
-      alpha3Code: 'BES',
-      numericCode: '535'
-    },
-    {
-      name: 'Bosnia y Herzegovina',
-      alpha2Code: 'BA',
-      alpha3Code: 'BIH',
-      numericCode: '070'
-    },
-    {
-      name: 'Botswana',
-      alpha2Code: 'BW',
-      alpha3Code: 'BWA',
-      numericCode: '072'
-    },
-    {
-      name: 'Isla Bouvet',
-      alpha2Code: 'BV',
-      alpha3Code: 'BVT',
-      numericCode: '074'
-    },
-    {
-      name: 'Brasil',
-      alpha2Code: 'BR',
-      alpha3Code: 'BRA',
-      numericCode: '076'
-    },
-    {
-      name: 'Brunei',
-      alpha2Code: 'BN',
-      alpha3Code: 'BRN',
-      numericCode: '096'
-    },
-    {
-      name: 'Bulgaria',
-      alpha2Code: 'BG',
-      alpha3Code: 'BGR',
-      numericCode: '100'
-    },
-    {
-      name: 'Burkina Faso',
-      alpha2Code: 'BF',
-      alpha3Code: 'BFA',
-      numericCode: '854'
-    },
-    {
-      name: 'Burundi',
-      alpha2Code: 'BI',
-      alpha3Code: 'BDI',
-      numericCode: '108'
-    },
-    {
-      name: 'Cabo Verde',
-      alpha2Code: 'CV',
-      alpha3Code: 'CPV',
-      numericCode: '132'
-    },
-    {
-      name: 'Camboya',
-      alpha2Code: 'KH',
-      alpha3Code: 'KHM',
-      numericCode: '116'
-    }, {
+  {
+    name: 'Albania',
+    alpha2Code: 'AL',
+    alpha3Code: 'ALB',
+    numericCode: '008'
+  },
+  {
+    name: 'Argelia',
+    alpha2Code: 'DZ',
+    alpha3Code: 'DZA',
+    numericCode: '012'
+  },
+  {
+    name: 'Samoa Americana',
+    alpha2Code: 'AS',
+    alpha3Code: 'ASM',
+    numericCode: '016'
+  },
+  {
+    name: 'Andorra',
+    alpha2Code: 'AD',
+    alpha3Code: 'Y',
+    numericCode: '020'
+  },
+  {
+    name: 'Angola',
+    alpha2Code: 'AO',
+    alpha3Code: 'AGO',
+    numericCode: '024'
+  },
+  {
+    name: 'Antigua y Barbuda',
+    alpha2Code: 'AG',
+    alpha3Code: 'ATG',
+    numericCode: '028'
+  },
+  {
+    name: 'Argentina',
+    alpha2Code: 'AR',
+    alpha3Code: 'ARG',
+    numericCode: '032'
+  },
+  {
+    name: 'Armenia',
+    alpha2Code: 'AM',
+    alpha3Code: 'ARM',
+    numericCode: '051'
+  },
+  {
+    name: 'Australia',
+    alpha2Code: 'AU',
+    alpha3Code: 'AUS',
+    numericCode: '036'
+  },
+  {
+    name: 'Austria',
+    alpha2Code: 'AT',
+    alpha3Code: 'AUT',
+    numericCode: '040'
+  },
+  {
+    name: 'Azerbaiyán',
+    alpha2Code: 'AZ',
+    alpha3Code: 'AZE',
+    numericCode: '031'
+  },
+  {
+    name: 'Bahamas',
+    alpha2Code: 'BS',
+    alpha3Code: 'BHS',
+    numericCode: '044'
+  },
+  {
+    name: 'Bahrein',
+    alpha2Code: 'BH',
+    alpha3Code: 'BHR',
+    numericCode: '048'
+  },
+  {
+    name: 'Bangladesh',
+    alpha2Code: 'BD',
+    alpha3Code: 'BGD',
+    numericCode: '050'
+  },
+  {
+    name: 'Barbados',
+    alpha2Code: 'BB',
+    alpha3Code: 'BRB',
+    numericCode: '052'
+  },
+  {
+    name: 'Bielorrusia',
+    alpha2Code: 'BY',
+    alpha3Code: 'BLR',
+    numericCode: '112'
+  },
+  {
+    name: 'Bélgica',
+    alpha2Code: 'BE',
+    alpha3Code: 'BEL',
+    numericCode: '056'
+  },
+  {
+    name: 'Belice',
+    alpha2Code: 'BZ',
+    alpha3Code: 'BLZ',
+    numericCode: '084'
+  },
+  {
+    name: 'Benin',
+    alpha2Code: 'BJ',
+    alpha3Code: 'BEN',
+    numericCode: '204'
+  },
+  {
+    name: 'Bermudas',
+    alpha2Code: 'BM',
+    alpha3Code: 'BMU',
+    numericCode: '060'
+  },
+  {
+    name: 'Bután',
+    alpha2Code: 'BT',
+    alpha3Code: 'BTN',
+    numericCode: '064'
+  },
+  {
+    name: 'Bolivia',
+    alpha2Code: 'BO',
+    alpha3Code: 'BOL',
+    numericCode: '068'
+  },
+  {
+    name: 'Bonaire, Sint Eustatius and Saba',
+    alpha2Code: 'BQ',
+    alpha3Code: 'BES',
+    numericCode: '535'
+  },
+  {
+    name: 'Bosnia y Herzegovina',
+    alpha2Code: 'BA',
+    alpha3Code: 'BIH',
+    numericCode: '070'
+  },
+  {
+    name: 'Botswana',
+    alpha2Code: 'BW',
+    alpha3Code: 'BWA',
+    numericCode: '072'
+  },
+  {
+    name: 'Isla Bouvet',
+    alpha2Code: 'BV',
+    alpha3Code: 'BVT',
+    numericCode: '074'
+  },
+  {
+    name: 'Brasil',
+    alpha2Code: 'BR',
+    alpha3Code: 'BRA',
+    numericCode: '076'
+  },
+  {
+    name: 'Brunei',
+    alpha2Code: 'BN',
+    alpha3Code: 'BRN',
+    numericCode: '096'
+  },
+  {
+    name: 'Bulgaria',
+    alpha2Code: 'BG',
+    alpha3Code: 'BGR',
+    numericCode: '100'
+  },
+  {
+    name: 'Burkina Faso',
+    alpha2Code: 'BF',
+    alpha3Code: 'BFA',
+    numericCode: '854'
+  },
+  {
+    name: 'Burundi',
+    alpha2Code: 'BI',
+    alpha3Code: 'BDI',
+    numericCode: '108'
+  },
+  {
+    name: 'Cabo Verde',
+    alpha2Code: 'CV',
+    alpha3Code: 'CPV',
+    numericCode: '132'
+  },
+  {
+    name: 'Camboya',
+    alpha2Code: 'KH',
+    alpha3Code: 'KHM',
+    numericCode: '116'
+  },
+  {
     name: 'Camerún',
     alpha2Code: 'CM',
     alpha3Code: 'CMR',
     numericCode: '120'
   },
-    {
-      name: 'Canadá',
-      alpha2Code: 'CA',
-      alpha3Code: 'CAN',
-      numericCode: '124'
-    },
-    {
-      name: 'República Centroafricana',
-      alpha2Code: 'CF',
-      alpha3Code: 'CAF',
-      numericCode: '140'
-    },
-    {
-      name: 'Chad',
-      alpha2Code: 'TD',
-      alpha3Code: 'TCD',
-      numericCode: '148'
-    },
-    {
-      name: 'Chile',
-      alpha2Code: 'CL',
-      alpha3Code: 'CHL',
-      numericCode: '152'
-    },
-    {
-      name: 'China',
-      alpha2Code: 'CN',
-      alpha3Code: 'CHN',
-      numericCode: '156'
-    },
-    {
-      name: 'Colombia',
-      alpha2Code: 'CO',
-      alpha3Code: 'COL',
-      numericCode: '170'
-    },
-    {
-      name: 'Congo (República Democrática del)',
-      alpha2Code: 'CD',
-      alpha3Code: 'COD',
-      numericCode: '180'
-    },
-    {
-      name: 'Congo (República del)',
-      alpha2Code: 'CG',
-      alpha3Code: 'COG',
-      numericCode: '178'
-    },
-    {
-      name: 'Costa Rica',
-      alpha2Code: 'CR',
-      alpha3Code: 'CRI',
-      numericCode: '188'
-    },
-    {
-      name: 'Croacia',
-      alpha2Code: 'HR',
-      alpha3Code: 'HRV',
-      numericCode: '191'
-    },
-    {
-      name: 'Cuba',
-      alpha2Code: 'CU',
-      alpha3Code: 'CUB',
-      numericCode: '192'
-    },
-    {
-      name: 'Chipre',
-      alpha2Code: 'CY',
-      alpha3Code: 'CYP',
-      numericCode: '196'
-    },
-    {
-      name: 'Chequia',
-      alpha2Code: 'CZ',
-      alpha3Code: 'CZE',
-      numericCode: '203'
-    },
-    {
-      name: 'Côte d \' Ivoire ',
-      alpha2Code: 'CI',
-      alpha3Code: 'CIV',
-      numericCode: '384'
-    },
-    {
-      name: 'Dinamarca',
-      alpha2Code: 'DK',
-      alpha3Code: 'DNK',
-      numericCode: '208'
-    },
-    {
-      name: 'Djibouti',
-      alpha2Code: 'DJ',
-      alpha3Code: 'DJI',
-      numericCode: '262'
-    },
-    {
-      name: 'Dominica',
-      alpha2Code: 'DM',
-      alpha3Code: 'DMA',
-      numericCode: '212'
-    },
-    {
-      name: 'República Dominicana',
-      alpha2Code: 'HACER',
-      alpha3Code: 'DOM',
-      numericCode: '214'
-    },
-    {
-      name: 'Ecuador',
-      alpha2Code: 'EC',
-      alpha3Code: 'ECU',
-      numericCode: '218'
-    },
-    {
-      name: 'Egipto',
-      alpha2Code: 'EG',
-      alpha3Code: 'EGY',
-      numericCode: '818'
-    },
-    {
-      name: 'El Salvador',
-      alpha2Code: 'SV',
-      alpha3Code: 'SLV',
-      numericCode: '222'
-    },
-    {
-      name: 'Guinea Ecuatorial',
-      alpha2Code: 'GQ',
-      alpha3Code: 'GNQ',
-      numericCode: '226'
-    },
-    {
-      name: 'Eritrea',
-      alpha2Code: 'ER',
-      alpha3Code: 'ERI',
-      numericCode: '232'
-    },
-    {
-      name: 'Estonia',
-      alpha2Code: 'EE',
-      alpha3Code: 'EST',
-      numericCode: '233'
-    },
-    {
-      name: 'Eswatini',
-      alpha2Code: 'SZ',
-      alpha3Code: 'SWZ',
-      numericCode: '748'
-    },
-    {
-      name: 'Etiopía',
-      alpha2Code: 'ET',
-      alpha3Code: 'ETH',
-      numericCode: '231'
-    },
-    {
-      name: 'Fiji',
-      alpha2Code: 'FJ',
-      alpha3Code: 'FJI',
-      numericCode: '242'
-    },
-    {
-      name: 'Finlandia',
-      alpha2Code: 'FI',
-      alpha3Code: 'FIN',
-      numericCode: '246'
-    },
-    {
-      name: 'Francia',
-      alpha2Code: 'FR',
-      alpha3Code: 'FRA',
-      numericCode: '250'
-    },
-    {
-      name: 'Gabón',
-      alpha2Code: 'GA',
-      alpha3Code: 'GAB',
-      numericCode: '266'
-    },
-    {
-      name: 'Gambia',
-      alpha2Code: 'GM',
-      alpha3Code: 'GMB',
-      numericCode: '270'
-    },
-    {
-      name: 'Georgia',
-      alpha2Code: 'GE',
-      alpha3Code: 'GEO',
-      numericCode: '268'
-    },
-    {
-      name: 'Alemania',
-      alpha2Code: 'DE',
-      alpha3Code: 'DEU',
-      numericCode: '276'
-    },
-    {
-      name: 'Ghana',
-      alpha2Code: 'GH',
-      alpha3Code: 'GHA',
-      numericCode: '288'
-    },
-    {
-      name: 'Grecia',
-      alpha2Code: 'GR',
-      alpha3Code: 'GRC',
-      numericCode: '300'
-    },
-    {
-      name: 'Groenlandia',
-      alpha2Code: 'GL',
-      alpha3Code: 'GRL',
-      numericCode: '304'
-    },
-    {
-      name: 'Guadalupe',
-      alpha2Code: 'GP',
-      alpha3Code: 'GLP',
-      numericCode: '312'
-    },
-    {
-      name: 'Granada',
-      alpha2Code: 'GD',
-      alpha3Code: 'GRD',
-      numericCode: '308'
-    }, {
+  {
+    name: 'Canadá',
+    alpha2Code: 'CA',
+    alpha3Code: 'CAN',
+    numericCode: '124'
+  },
+  {
+    name: 'República Centroafricana',
+    alpha2Code: 'CF',
+    alpha3Code: 'CAF',
+    numericCode: '140'
+  },
+  {
+    name: 'Chad',
+    alpha2Code: 'TD',
+    alpha3Code: 'TCD',
+    numericCode: '148'
+  },
+  {
+    name: 'Chile',
+    alpha2Code: 'CL',
+    alpha3Code: 'CHL',
+    numericCode: '152'
+  },
+  {
+    name: 'China',
+    alpha2Code: 'CN',
+    alpha3Code: 'CHN',
+    numericCode: '156'
+  },
+  {
+    name: 'Colombia',
+    alpha2Code: 'CO',
+    alpha3Code: 'COL',
+    numericCode: '170'
+  },
+  {
+    name: 'Congo (República Democrática del)',
+    alpha2Code: 'CD',
+    alpha3Code: 'COD',
+    numericCode: '180'
+  },
+  {
+    name: 'Congo (República del)',
+    alpha2Code: 'CG',
+    alpha3Code: 'COG',
+    numericCode: '178'
+  },
+  {
+    name: 'Costa Rica',
+    alpha2Code: 'CR',
+    alpha3Code: 'CRI',
+    numericCode: '188'
+  },
+  {
+    name: 'Croacia',
+    alpha2Code: 'HR',
+    alpha3Code: 'HRV',
+    numericCode: '191'
+  },
+  {
+    name: 'Cuba',
+    alpha2Code: 'CU',
+    alpha3Code: 'CUB',
+    numericCode: '192'
+  },
+  {
+    name: 'Chipre',
+    alpha2Code: 'CY',
+    alpha3Code: 'CYP',
+    numericCode: '196'
+  },
+  {
+    name: 'Chequia',
+    alpha2Code: 'CZ',
+    alpha3Code: 'CZE',
+    numericCode: '203'
+  },
+  {
+    name: "Côte d ' Ivoire ",
+    alpha2Code: 'CI',
+    alpha3Code: 'CIV',
+    numericCode: '384'
+  },
+  {
+    name: 'Dinamarca',
+    alpha2Code: 'DK',
+    alpha3Code: 'DNK',
+    numericCode: '208'
+  },
+  {
+    name: 'Djibouti',
+    alpha2Code: 'DJ',
+    alpha3Code: 'DJI',
+    numericCode: '262'
+  },
+  {
+    name: 'Dominica',
+    alpha2Code: 'DM',
+    alpha3Code: 'DMA',
+    numericCode: '212'
+  },
+  {
+    name: 'República Dominicana',
+    alpha2Code: 'HACER',
+    alpha3Code: 'DOM',
+    numericCode: '214'
+  },
+  {
+    name: 'Ecuador',
+    alpha2Code: 'EC',
+    alpha3Code: 'ECU',
+    numericCode: '218'
+  },
+  {
+    name: 'Egipto',
+    alpha2Code: 'EG',
+    alpha3Code: 'EGY',
+    numericCode: '818'
+  },
+  {
+    name: 'El Salvador',
+    alpha2Code: 'SV',
+    alpha3Code: 'SLV',
+    numericCode: '222'
+  },
+  {
+    name: 'Guinea Ecuatorial',
+    alpha2Code: 'GQ',
+    alpha3Code: 'GNQ',
+    numericCode: '226'
+  },
+  {
+    name: 'Eritrea',
+    alpha2Code: 'ER',
+    alpha3Code: 'ERI',
+    numericCode: '232'
+  },
+  {
+    name: 'Estonia',
+    alpha2Code: 'EE',
+    alpha3Code: 'EST',
+    numericCode: '233'
+  },
+  {
+    name: 'Eswatini',
+    alpha2Code: 'SZ',
+    alpha3Code: 'SWZ',
+    numericCode: '748'
+  },
+  {
+    name: 'Etiopía',
+    alpha2Code: 'ET',
+    alpha3Code: 'ETH',
+    numericCode: '231'
+  },
+  {
+    name: 'Fiji',
+    alpha2Code: 'FJ',
+    alpha3Code: 'FJI',
+    numericCode: '242'
+  },
+  {
+    name: 'Finlandia',
+    alpha2Code: 'FI',
+    alpha3Code: 'FIN',
+    numericCode: '246'
+  },
+  {
+    name: 'Francia',
+    alpha2Code: 'FR',
+    alpha3Code: 'FRA',
+    numericCode: '250'
+  },
+  {
+    name: 'Gabón',
+    alpha2Code: 'GA',
+    alpha3Code: 'GAB',
+    numericCode: '266'
+  },
+  {
+    name: 'Gambia',
+    alpha2Code: 'GM',
+    alpha3Code: 'GMB',
+    numericCode: '270'
+  },
+  {
+    name: 'Georgia',
+    alpha2Code: 'GE',
+    alpha3Code: 'GEO',
+    numericCode: '268'
+  },
+  {
+    name: 'Alemania',
+    alpha2Code: 'DE',
+    alpha3Code: 'DEU',
+    numericCode: '276'
+  },
+  {
+    name: 'Ghana',
+    alpha2Code: 'GH',
+    alpha3Code: 'GHA',
+    numericCode: '288'
+  },
+  {
+    name: 'Grecia',
+    alpha2Code: 'GR',
+    alpha3Code: 'GRC',
+    numericCode: '300'
+  },
+  {
+    name: 'Groenlandia',
+    alpha2Code: 'GL',
+    alpha3Code: 'GRL',
+    numericCode: '304'
+  },
+  {
+    name: 'Guadalupe',
+    alpha2Code: 'GP',
+    alpha3Code: 'GLP',
+    numericCode: '312'
+  },
+  {
+    name: 'Granada',
+    alpha2Code: 'GD',
+    alpha3Code: 'GRD',
+    numericCode: '308'
+  },
+  {
     name: 'Guatemala',
     alpha2Code: 'GT',
     alpha3Code: 'GTM',
     numericCode: '320'
   },
-    {
-      name: 'Guinea',
-      alpha2Code: 'GN',
-      alpha3Code: 'GIN',
-      numericCode: '324'
-    },
-    {
-      name: 'Guinea-Bissau',
-      alpha2Code: 'GW',
-      alpha3Code: 'GNB',
-      numericCode: '624'
-    },
-    {
-      name: 'Guyana',
-      alpha2Code: 'GY',
-      alpha3Code: 'GUY',
-      numericCode: '328'
-    },
-    {
-      name: 'Haití',
-      alpha2Code: 'HT',
-      alpha3Code: 'HTI',
-      numericCode: '332'
-    },
-    {
-      name: 'Honduras',
-      alpha2Code: 'HN',
-      alpha3Code: 'HND',
-      numericCode: '340'
-    },
-    {
-      name: 'Hong Kong',
-      alpha2Code: 'HK',
-      alpha3Code: 'HKG',
-      numericCode: '344'
-    },
-    {
-      name: 'Hungría',
-      alpha2Code: 'HU',
-      alpha3Code: 'HUN',
-      numericCode: '348'
-    },
-    {
-      name: 'Islandia',
-      alpha2Code: 'IS',
-      alpha3Code: 'ISL',
-      numericCode: '352'
-    },
-    {
-      name: 'India',
-      alpha2Code: 'IN',
-      alpha3Code: 'IND',
-      numericCode: '356'
-    },
-    {
-      name: 'Indonesia',
-      alpha2Code: 'ID',
-      alpha3Code: 'IDN',
-      numericCode: '360'
-    },
-    {
-      name: 'Irán',
-      alpha2Code: 'IR',
-      alpha3Code: 'IRN',
-      numericCode: '364'
-    },
-    {
-      name: 'Irak',
-      alpha2Code: 'IQ',
-      alpha3Code: 'IRQ',
-      numericCode: '368'
-    },
-    {
-      name: 'Irlanda',
-      alpha2Code: 'IE',
-      alpha3Code: 'IRL',
-      numericCode: '372'
-    },
-    {
-      name: 'Israel',
-      alpha2Code: 'IL',
-      alpha3Code: 'ISR',
-      numericCode: '376'
-    },
-    {
-      name: 'Italia',
-      alpha2Code: 'IT',
-      alpha3Code: 'ITA',
-      numericCode: '380'
-    },
-    {
-      name: 'Jamaica',
-      alpha2Code: 'JM',
-      alpha3Code: 'JAM',
-      numericCode: '388'
-    },
-    {
-      name: 'Japón',
-      alpha2Code: 'JP',
-      alpha3Code: 'JPN',
-      numericCode: '392'
-    },
-    {
-      name: 'Jersey',
-      alpha2Code: 'JE',
-      alpha3Code: 'JEY',
-      numericCode: '832'
-    },
-    {
-      name: 'Jordan',
-      alpha2Code: 'JO',
-      alpha3Code: 'JOR',
-      numericCode: '400'
-    },
-    {
-      name: 'Kazajstán',
-      alpha2Code: 'KZ',
-      alpha3Code: 'KAZ',
-      numericCode: '398'
-    },
-    {
-      name: 'Kenia',
-      alpha2Code: 'KE',
-      alpha3Code: 'KEN',
-      numericCode: '404'
-    },
-    {
-      name: 'Kiribati',
-      alpha2Code: 'KI',
-      alpha3Code: 'KIR',
-      numericCode: '296'
-    },
-    {
-      name: 'Corea (República Popular Democrática de)',
-      alpha2Code: 'KP',
-      alpha3Code: 'PRK',
-      numericCode: '408'
-    },
-    {
-      name: 'Corea (República de) \ t',
-      alpha2Code: 'KR',
-      alpha3Code: 'KOR',
-      numericCode: '410'
-    },
-    {
-      name: 'Kuwait',
-      alpha2Code: 'KW',
-      alpha3Code: 'KWT',
-      numericCode: '414'
-    },
-    {
-      name: 'Kirguistán',
-      alpha2Code: 'KG',
-      alpha3Code: 'KGZ',
-      numericCode: '417'
-    },
-    {
-      name: 'Laos',
-      alpha2Code: 'LA',
-      alpha3Code: 'LAO',
-      numericCode: '418'
-    },
-    {
-      name: 'Letonia',
-      alpha2Code: 'LV',
-      alpha3Code: 'LVA',
-      numericCode: '428'
-    },
-    {
-      name: 'Líbano',
-      alpha2Code: 'LB',
-      alpha3Code: 'LBN',
-      numericCode: '422'
-    },
-    {
-      name: 'Lesotho',
-      alpha2Code: 'LS',
-      alpha3Code: 'LSO',
-      numericCode: '426'
-    },
-    {
-      name: 'Liberia',
-      alpha2Code: 'LR',
-      alpha3Code: 'LBR',
-      numericCode: '430'
-    },
-    {
-      name: 'Libia',
-      alpha2Code: 'LY',
-      alpha3Code: 'LBY',
-      numericCode: '434'
-    },
-    {
-      name: 'Liechtenstein',
-      alpha2Code: 'LI',
-      alpha3Code: 'LIE',
-      numericCode: '438'
-    }, {
+  {
+    name: 'Guinea',
+    alpha2Code: 'GN',
+    alpha3Code: 'GIN',
+    numericCode: '324'
+  },
+  {
+    name: 'Guinea-Bissau',
+    alpha2Code: 'GW',
+    alpha3Code: 'GNB',
+    numericCode: '624'
+  },
+  {
+    name: 'Guyana',
+    alpha2Code: 'GY',
+    alpha3Code: 'GUY',
+    numericCode: '328'
+  },
+  {
+    name: 'Haití',
+    alpha2Code: 'HT',
+    alpha3Code: 'HTI',
+    numericCode: '332'
+  },
+  {
+    name: 'Honduras',
+    alpha2Code: 'HN',
+    alpha3Code: 'HND',
+    numericCode: '340'
+  },
+  {
+    name: 'Hong Kong',
+    alpha2Code: 'HK',
+    alpha3Code: 'HKG',
+    numericCode: '344'
+  },
+  {
+    name: 'Hungría',
+    alpha2Code: 'HU',
+    alpha3Code: 'HUN',
+    numericCode: '348'
+  },
+  {
+    name: 'Islandia',
+    alpha2Code: 'IS',
+    alpha3Code: 'ISL',
+    numericCode: '352'
+  },
+  {
+    name: 'India',
+    alpha2Code: 'IN',
+    alpha3Code: 'IND',
+    numericCode: '356'
+  },
+  {
+    name: 'Indonesia',
+    alpha2Code: 'ID',
+    alpha3Code: 'IDN',
+    numericCode: '360'
+  },
+  {
+    name: 'Irán',
+    alpha2Code: 'IR',
+    alpha3Code: 'IRN',
+    numericCode: '364'
+  },
+  {
+    name: 'Irak',
+    alpha2Code: 'IQ',
+    alpha3Code: 'IRQ',
+    numericCode: '368'
+  },
+  {
+    name: 'Irlanda',
+    alpha2Code: 'IE',
+    alpha3Code: 'IRL',
+    numericCode: '372'
+  },
+  {
+    name: 'Israel',
+    alpha2Code: 'IL',
+    alpha3Code: 'ISR',
+    numericCode: '376'
+  },
+  {
+    name: 'Italia',
+    alpha2Code: 'IT',
+    alpha3Code: 'ITA',
+    numericCode: '380'
+  },
+  {
+    name: 'Jamaica',
+    alpha2Code: 'JM',
+    alpha3Code: 'JAM',
+    numericCode: '388'
+  },
+  {
+    name: 'Japón',
+    alpha2Code: 'JP',
+    alpha3Code: 'JPN',
+    numericCode: '392'
+  },
+  {
+    name: 'Jersey',
+    alpha2Code: 'JE',
+    alpha3Code: 'JEY',
+    numericCode: '832'
+  },
+  {
+    name: 'Jordan',
+    alpha2Code: 'JO',
+    alpha3Code: 'JOR',
+    numericCode: '400'
+  },
+  {
+    name: 'Kazajstán',
+    alpha2Code: 'KZ',
+    alpha3Code: 'KAZ',
+    numericCode: '398'
+  },
+  {
+    name: 'Kenia',
+    alpha2Code: 'KE',
+    alpha3Code: 'KEN',
+    numericCode: '404'
+  },
+  {
+    name: 'Kiribati',
+    alpha2Code: 'KI',
+    alpha3Code: 'KIR',
+    numericCode: '296'
+  },
+  {
+    name: 'Corea (República Popular Democrática de)',
+    alpha2Code: 'KP',
+    alpha3Code: 'PRK',
+    numericCode: '408'
+  },
+  {
+    name: 'Corea (República de)  t',
+    alpha2Code: 'KR',
+    alpha3Code: 'KOR',
+    numericCode: '410'
+  },
+  {
+    name: 'Kuwait',
+    alpha2Code: 'KW',
+    alpha3Code: 'KWT',
+    numericCode: '414'
+  },
+  {
+    name: 'Kirguistán',
+    alpha2Code: 'KG',
+    alpha3Code: 'KGZ',
+    numericCode: '417'
+  },
+  {
+    name: 'Laos',
+    alpha2Code: 'LA',
+    alpha3Code: 'LAO',
+    numericCode: '418'
+  },
+  {
+    name: 'Letonia',
+    alpha2Code: 'LV',
+    alpha3Code: 'LVA',
+    numericCode: '428'
+  },
+  {
+    name: 'Líbano',
+    alpha2Code: 'LB',
+    alpha3Code: 'LBN',
+    numericCode: '422'
+  },
+  {
+    name: 'Lesotho',
+    alpha2Code: 'LS',
+    alpha3Code: 'LSO',
+    numericCode: '426'
+  },
+  {
+    name: 'Liberia',
+    alpha2Code: 'LR',
+    alpha3Code: 'LBR',
+    numericCode: '430'
+  },
+  {
+    name: 'Libia',
+    alpha2Code: 'LY',
+    alpha3Code: 'LBY',
+    numericCode: '434'
+  },
+  {
+    name: 'Liechtenstein',
+    alpha2Code: 'LI',
+    alpha3Code: 'LIE',
+    numericCode: '438'
+  },
+  {
     name: 'Lituania',
     alpha2Code: 'LT',
     alpha3Code: 'LTU',
     numericCode: '440'
   },
-    {
-      name: 'Luxemburgo',
-      alpha2Code: 'LU',
-      alpha3Code: 'LUX',
-      numericCode: '442'
-    },
-    {
-      name: 'Macao',
-      alpha2Code: 'MO',
-      alpha3Code: 'MAC',
-      numericCode: '446'
-    },
-    {
-      name: 'Madagascar',
-      alpha2Code: 'MG',
-      alpha3Code: 'MDG',
-      numericCode: '450'
-    },
-    {
-      name: 'Malawi',
-      alpha2Code: 'MW',
-      alpha3Code: 'MWI',
-      numericCode: '454'
-    },
-    {
-      name: 'Malasia',
-      alpha2Code: 'MI',
-      alpha3Code: 'MYS',
-      numericCode: '458'
-    },
-    {
-      name: 'Maldivas',
-      alpha2Code: 'MV',
-      alpha3Code: 'MDV',
-      numericCode: '462'
-    },
-    {
-      name: 'Mali',
-      alpha2Code: 'ML',
-      alpha3Code: 'MLI',
-      numericCode: '466'
-    },
-    {
-      name: 'Malta',
-      alpha2Code: 'MT',
-      alpha3Code: 'MLT',
-      numericCode: '470'
-    },
-    {
-      name: 'Mauritania',
-      alpha2Code: 'MR',
-      alpha3Code: 'MRT',
-      numericCode: '478'
-    },
-    {
-      name: 'Mauricio',
-      alpha2Code: 'MU',
-      alpha3Code: 'MUS',
-      numericCode: '480'
-    },
-    {
-      name: 'México',
-      alpha2Code: 'MX',
-      alpha3Code: 'MEX',
-      numericCode: '484'
-    },
-    {
-      name: 'Moldavia',
-      alpha2Code: 'MD',
-      alpha3Code: 'MDA',
-      numericCode: '498'
-    },
-    {
-      name: 'Mónaco',
-      alpha2Code: 'MC',
-      alpha3Code: 'MCO',
-      numericCode: '492'
-    },
-    {
-      name: 'Mongolia',
-      alpha2Code: 'MN',
-      alpha3Code: 'MNG',
-      numericCode: '496'
-    },
-    {
-      name: 'Montenegro',
-      alpha2Code: 'YO',
-      alpha3Code: 'MNE',
-      numericCode: '499'
-    },
-    {
-      name: 'Marruecos',
-      alpha2Code: 'MA',
-      alpha3Code: 'MAR',
-      numericCode: '504'
-    },
-    {
-      name: 'Mozambique',
-      alpha2Code: 'MZ',
-      alpha3Code: 'MOZ',
-      numericCode: '508'
-    },
-    {
-      name: 'Myanmar',
-      alpha2Code: 'MM',
-      alpha3Code: 'MMR',
-      numericCode: '104'
-    },
-    {
-      name: 'Namibia',
-      alpha2Code: 'NA',
-      alpha3Code: 'NAM',
-      numericCode: '516'
-    },
-    {
-      name: 'Nauru',
-      alpha2Code: 'NR',
-      alpha3Code: 'NRU',
-      numericCode: '520'
-    },
-    {
-      name: 'Nepal',
-      alpha2Code: 'NP',
-      alpha3Code: 'NPL',
-      numericCode: '524'
-    },
-    {
-      name: 'Holanda',
-      alpha2Code: 'NL',
-      alpha3Code: 'NLD',
-      numericCode: '528'
-    },
-    {
-      name: 'Nueva Caledonia',
-      alpha2Code: 'NC',
-      alpha3Code: 'NCL',
-      numericCode: '540'
-    },
-    {
-      name: 'Nueva Zelanda',
-      alpha2Code: 'NZ',
-      alpha3Code: 'NZL',
-      numericCode: '554'
-    },
-    {
-      name: 'Nicaragua',
-      alpha2Code: 'NI',
-      alpha3Code: 'NIC',
-      numericCode: '558'
-    },
-    {
-      name: 'Níger',
-      alpha2Code: 'NE',
-      alpha3Code: 'NER',
-      numericCode: '562'
-    },
-    {
-      name: 'Nigeria',
-      alpha2Code: 'NG',
-      alpha3Code: 'NGA',
-      numericCode: '566'
-    },
-    {
-      name: 'Noruega',
-      alpha2Code: 'NO',
-      alpha3Code: 'NOR',
-      numericCode: '578'
-    },
-    {
-      name: 'Omán',
-      alpha2Code: 'OM',
-      alpha3Code: 'OMN',
-      numericCode: '512'
-    },
-    {
-      name: 'Pakistán',
-      alpha2Code: 'PK',
-      alpha3Code: 'PAK',
-      numericCode: '586'
-    },
-    {
-      name: 'Palau',
-      alpha2Code: 'PW',
-      alpha3Code: 'PLW',
-      numericCode: '585'
-    },
-    {
-      name: 'Palestina',
-      alpha2Code: 'PS',
-      alpha3Code: 'PSE',
-      numericCode: '275'
-    },
-    {
-      name: 'Panamá',
-      alpha2Code: 'PA',
-      alpha3Code: 'PAN',
-      numericCode: '591'
-    },
-    {
-      name: 'Papua Nueva Guinea',
-      alpha2Code: 'PG',
-      alpha3Code: 'PNG',
-      numericCode: '598'
-    },
-    {
-      name: 'Paraguay',
-      alpha2Code: 'PY',
-      alpha3Code: 'PRY',
-      numericCode: '600'
-    },
-    {
-      name: 'Perú',
-      alpha2Code: 'PE',
-      alpha3Code: 'PER',
-      numericCode: '604'
-    },
-    {
-      name: 'Filipinas',
-      alpha2Code: 'PH',
-      alpha3Code: 'PHL',
-      numericCode: '608'
-    },
-    {
-      name: 'Polonia',
-      alpha2Code: 'PL',
-      alpha3Code: 'POL',
-      numericCode: '616'
-    }, {
+  {
+    name: 'Luxemburgo',
+    alpha2Code: 'LU',
+    alpha3Code: 'LUX',
+    numericCode: '442'
+  },
+  {
+    name: 'Macao',
+    alpha2Code: 'MO',
+    alpha3Code: 'MAC',
+    numericCode: '446'
+  },
+  {
+    name: 'Madagascar',
+    alpha2Code: 'MG',
+    alpha3Code: 'MDG',
+    numericCode: '450'
+  },
+  {
+    name: 'Malawi',
+    alpha2Code: 'MW',
+    alpha3Code: 'MWI',
+    numericCode: '454'
+  },
+  {
+    name: 'Malasia',
+    alpha2Code: 'MI',
+    alpha3Code: 'MYS',
+    numericCode: '458'
+  },
+  {
+    name: 'Maldivas',
+    alpha2Code: 'MV',
+    alpha3Code: 'MDV',
+    numericCode: '462'
+  },
+  {
+    name: 'Mali',
+    alpha2Code: 'ML',
+    alpha3Code: 'MLI',
+    numericCode: '466'
+  },
+  {
+    name: 'Malta',
+    alpha2Code: 'MT',
+    alpha3Code: 'MLT',
+    numericCode: '470'
+  },
+  {
+    name: 'Mauritania',
+    alpha2Code: 'MR',
+    alpha3Code: 'MRT',
+    numericCode: '478'
+  },
+  {
+    name: 'Mauricio',
+    alpha2Code: 'MU',
+    alpha3Code: 'MUS',
+    numericCode: '480'
+  },
+  {
+    name: 'México',
+    alpha2Code: 'MX',
+    alpha3Code: 'MEX',
+    numericCode: '484'
+  },
+  {
+    name: 'Moldavia',
+    alpha2Code: 'MD',
+    alpha3Code: 'MDA',
+    numericCode: '498'
+  },
+  {
+    name: 'Mónaco',
+    alpha2Code: 'MC',
+    alpha3Code: 'MCO',
+    numericCode: '492'
+  },
+  {
+    name: 'Mongolia',
+    alpha2Code: 'MN',
+    alpha3Code: 'MNG',
+    numericCode: '496'
+  },
+  {
+    name: 'Montenegro',
+    alpha2Code: 'YO',
+    alpha3Code: 'MNE',
+    numericCode: '499'
+  },
+  {
+    name: 'Marruecos',
+    alpha2Code: 'MA',
+    alpha3Code: 'MAR',
+    numericCode: '504'
+  },
+  {
+    name: 'Mozambique',
+    alpha2Code: 'MZ',
+    alpha3Code: 'MOZ',
+    numericCode: '508'
+  },
+  {
+    name: 'Myanmar',
+    alpha2Code: 'MM',
+    alpha3Code: 'MMR',
+    numericCode: '104'
+  },
+  {
+    name: 'Namibia',
+    alpha2Code: 'NA',
+    alpha3Code: 'NAM',
+    numericCode: '516'
+  },
+  {
+    name: 'Nauru',
+    alpha2Code: 'NR',
+    alpha3Code: 'NRU',
+    numericCode: '520'
+  },
+  {
+    name: 'Nepal',
+    alpha2Code: 'NP',
+    alpha3Code: 'NPL',
+    numericCode: '524'
+  },
+  {
+    name: 'Holanda',
+    alpha2Code: 'NL',
+    alpha3Code: 'NLD',
+    numericCode: '528'
+  },
+  {
+    name: 'Nueva Caledonia',
+    alpha2Code: 'NC',
+    alpha3Code: 'NCL',
+    numericCode: '540'
+  },
+  {
+    name: 'Nueva Zelanda',
+    alpha2Code: 'NZ',
+    alpha3Code: 'NZL',
+    numericCode: '554'
+  },
+  {
+    name: 'Nicaragua',
+    alpha2Code: 'NI',
+    alpha3Code: 'NIC',
+    numericCode: '558'
+  },
+  {
+    name: 'Níger',
+    alpha2Code: 'NE',
+    alpha3Code: 'NER',
+    numericCode: '562'
+  },
+  {
+    name: 'Nigeria',
+    alpha2Code: 'NG',
+    alpha3Code: 'NGA',
+    numericCode: '566'
+  },
+  {
+    name: 'Noruega',
+    alpha2Code: 'NO',
+    alpha3Code: 'NOR',
+    numericCode: '578'
+  },
+  {
+    name: 'Omán',
+    alpha2Code: 'OM',
+    alpha3Code: 'OMN',
+    numericCode: '512'
+  },
+  {
+    name: 'Pakistán',
+    alpha2Code: 'PK',
+    alpha3Code: 'PAK',
+    numericCode: '586'
+  },
+  {
+    name: 'Palau',
+    alpha2Code: 'PW',
+    alpha3Code: 'PLW',
+    numericCode: '585'
+  },
+  {
+    name: 'Palestina',
+    alpha2Code: 'PS',
+    alpha3Code: 'PSE',
+    numericCode: '275'
+  },
+  {
+    name: 'Panamá',
+    alpha2Code: 'PA',
+    alpha3Code: 'PAN',
+    numericCode: '591'
+  },
+  {
+    name: 'Papua Nueva Guinea',
+    alpha2Code: 'PG',
+    alpha3Code: 'PNG',
+    numericCode: '598'
+  },
+  {
+    name: 'Paraguay',
+    alpha2Code: 'PY',
+    alpha3Code: 'PRY',
+    numericCode: '600'
+  },
+  {
+    name: 'Perú',
+    alpha2Code: 'PE',
+    alpha3Code: 'PER',
+    numericCode: '604'
+  },
+  {
+    name: 'Filipinas',
+    alpha2Code: 'PH',
+    alpha3Code: 'PHL',
+    numericCode: '608'
+  },
+  {
+    name: 'Polonia',
+    alpha2Code: 'PL',
+    alpha3Code: 'POL',
+    numericCode: '616'
+  },
+  {
     name: 'Portugal',
     alpha2Code: 'PT',
     alpha3Code: 'PRT',
     numericCode: '620'
   },
-    {
-      name: 'Puerto Rico',
-      alpha2Code: 'PR',
-      alpha3Code: 'PRI',
-      numericCode: '630'
-    },
-    {
-      name: 'Qatar',
-      alpha2Code: 'QA',
-      alpha3Code: 'QAT',
-      numericCode: '634'
-    },
-    {
-      name: 'República de Macedonia del Norte',
-      alpha2Code: 'MK',
-      alpha3Code: 'MKD',
-      numericCode: '807'
-    },
-    {
-      name: 'Rumania',
-      alpha2Code: 'RO',
-      alpha3Code: 'ROU',
-      numericCode: '642'
-    },
-    {
-      name: 'Federación de Rusia (la)',
-      alpha2Code: 'RU',
-      alpha3Code: 'RUS',
-      numericCode: '643'
-    },
-    {
-      name: 'Ruanda',
-      alpha2Code: 'RW',
-      alpha3Code: 'RWA',
-      numericCode: '646'
-    },
-    {
-      name: 'Saint Kitts y Nevis',
-      alpha2Code: 'KN',
-      alpha3Code: 'KNA',
-      numericCode: '659'
-    },
-    {
-      name: 'Santa Lucía',
-      alpha2Code: 'LC',
-      alpha3Code: 'LCA',
-      numericCode: '662'
-    },
-    {
-      name: 'San Vicente y las Granadinas',
-      alpha2Code: 'VC',
-      alpha3Code: 'VCT',
-      numericCode: '670'
-    },
-    {
-      name: 'Samoa',
-      alpha2Code: 'WS',
-      alpha3Code: 'WSM',
-      numericCode: '882'
-    },
-    {
-      name: 'San Marino',
-      alpha2Code: 'SM',
-      alpha3Code: 'SMR',
-      numericCode: '674'
-    },
-    {
-      name: 'Santo Tomé y Príncipe',
-      alpha2Code: 'ST',
-      alpha3Code: 'STP',
-      numericCode: '678'
-    },
-    {
-      name: 'Arabia Saudita',
-      alpha2Code: 'SA',
-      alpha3Code: 'SAU',
-      numericCode: '682'
-    },
-    {
-      name: 'Senegal',
-      alpha2Code: 'SN',
-      alpha3Code: 'SEN',
-      numericCode: '686'
-    },
-    {
-      name: 'Serbia',
-      alpha2Code: 'RS',
-      alpha3Code: 'SRB',
-      numericCode: '688'
-    },
-    {
-      name: 'Seychelles',
-      alpha2Code: 'SC',
-      alpha3Code: 'SYC',
-      numericCode: '690'
-    },
-    {
-      name: 'Sierra Leona',
-      alpha2Code: 'SL',
-      alpha3Code: 'SLE',
-      numericCode: '694'
-    },
-    {
-      name: 'Singapur',
-      alpha2Code: 'SG',
-      alpha3Code: 'SGP',
-      numericCode: '702'
-    },
-    {
-      name: 'Eslovaquia',
-      alpha2Code: 'SK',
-      alpha3Code: 'SVK',
-      numericCode: '703'
-    },
-    {
-      name: 'Eslovenia',
-      alpha2Code: 'SI',
-      alpha3Code: 'SVN',
-      numericCode: '705'
-    },
-    {
-      name: 'Islas Salomón',
-      alpha2Code: 'SB',
-      alpha3Code: 'SLB',
-      numericCode: '090'
-    },
-    {
-      name: 'Somalia',
-      alpha2Code: 'SO',
-      alpha3Code: 'SOM',
-      numericCode: '706'
-    },
-    {
-      name: 'Sudáfrica',
-      alpha2Code: 'ZA',
-      alpha3Code: 'ZAF',
-      numericCode: '710'
-    },
-    {
-      name: 'Sudán del Sur',
-      alpha2Code: 'SS',
-      alpha3Code: 'SSD',
-      numericCode: '728'
-    },
-    {
-      name: 'España',
-      alpha2Code: 'ES',
-      alpha3Code: 'ESP',
-      numericCode: '724'
-    },
-    {
-      name: 'Sri Lanka',
-      alpha2Code: 'LK',
-      alpha3Code: 'LKA',
-      numericCode: '144'
-    },
-    {
-      name: 'Sudán',
-      alpha2Code: 'SD',
-      alpha3Code: 'SDN',
-      numericCode: '729'
-    },
-    {
-      name: 'Surinam',
-      alpha2Code: 'SR',
-      alpha3Code: 'SUR',
-      numericCode: '740'
-    },
-    {
-      name: 'Suecia',
-      alpha2Code: 'SE',
-      alpha3Code: 'SWE',
-      numericCode: '752'
-    },
-    {
-      name: 'Suiza',
-      alpha2Code: 'CH',
-      alpha3Code: 'CHE',
-      numericCode: '756'
-    },
-    {
-      name: 'República Árabe Siria',
-      alpha2Code: 'SY',
-      alpha3Code: 'SYR',
-      numericCode: '760'
-    },
-    {
-      name: 'Taiwán',
-      alpha2Code: 'TW',
-      alpha3Code: 'TWN',
-      numericCode: '158'
-    },
-    {
-      name: 'Tayikistán',
-      alpha2Code: 'TJ',
-      alpha3Code: 'TJK',
-      numericCode: '762'
-    },
-    {
-      name: 'Tanzania',
-      alpha2Code: 'TZ',
-      alpha3Code: 'TZA',
-      numericCode: '834'
-    },
-    {
-      name: 'Tailandia',
-      alpha2Code: 'TH',
-      alpha3Code: 'THA',
-      numericCode: '764'
-    },
-    {
-      name: 'Timor-Leste',
-      alpha2Code: 'TL',
-      alpha3Code: 'TLS',
-      numericCode: '626'
-    },
-    {
-      name: 'Togo',
-      alpha2Code: 'TG',
-      alpha3Code: 'TGO',
-      numericCode: '768'
-    }, {
+  {
+    name: 'Puerto Rico',
+    alpha2Code: 'PR',
+    alpha3Code: 'PRI',
+    numericCode: '630'
+  },
+  {
+    name: 'Qatar',
+    alpha2Code: 'QA',
+    alpha3Code: 'QAT',
+    numericCode: '634'
+  },
+  {
+    name: 'República de Macedonia del Norte',
+    alpha2Code: 'MK',
+    alpha3Code: 'MKD',
+    numericCode: '807'
+  },
+  {
+    name: 'Rumania',
+    alpha2Code: 'RO',
+    alpha3Code: 'ROU',
+    numericCode: '642'
+  },
+  {
+    name: 'Federación de Rusia (la)',
+    alpha2Code: 'RU',
+    alpha3Code: 'RUS',
+    numericCode: '643'
+  },
+  {
+    name: 'Ruanda',
+    alpha2Code: 'RW',
+    alpha3Code: 'RWA',
+    numericCode: '646'
+  },
+  {
+    name: 'Saint Kitts y Nevis',
+    alpha2Code: 'KN',
+    alpha3Code: 'KNA',
+    numericCode: '659'
+  },
+  {
+    name: 'Santa Lucía',
+    alpha2Code: 'LC',
+    alpha3Code: 'LCA',
+    numericCode: '662'
+  },
+  {
+    name: 'San Vicente y las Granadinas',
+    alpha2Code: 'VC',
+    alpha3Code: 'VCT',
+    numericCode: '670'
+  },
+  {
+    name: 'Samoa',
+    alpha2Code: 'WS',
+    alpha3Code: 'WSM',
+    numericCode: '882'
+  },
+  {
+    name: 'San Marino',
+    alpha2Code: 'SM',
+    alpha3Code: 'SMR',
+    numericCode: '674'
+  },
+  {
+    name: 'Santo Tomé y Príncipe',
+    alpha2Code: 'ST',
+    alpha3Code: 'STP',
+    numericCode: '678'
+  },
+  {
+    name: 'Arabia Saudita',
+    alpha2Code: 'SA',
+    alpha3Code: 'SAU',
+    numericCode: '682'
+  },
+  {
+    name: 'Senegal',
+    alpha2Code: 'SN',
+    alpha3Code: 'SEN',
+    numericCode: '686'
+  },
+  {
+    name: 'Serbia',
+    alpha2Code: 'RS',
+    alpha3Code: 'SRB',
+    numericCode: '688'
+  },
+  {
+    name: 'Seychelles',
+    alpha2Code: 'SC',
+    alpha3Code: 'SYC',
+    numericCode: '690'
+  },
+  {
+    name: 'Sierra Leona',
+    alpha2Code: 'SL',
+    alpha3Code: 'SLE',
+    numericCode: '694'
+  },
+  {
+    name: 'Singapur',
+    alpha2Code: 'SG',
+    alpha3Code: 'SGP',
+    numericCode: '702'
+  },
+  {
+    name: 'Eslovaquia',
+    alpha2Code: 'SK',
+    alpha3Code: 'SVK',
+    numericCode: '703'
+  },
+  {
+    name: 'Eslovenia',
+    alpha2Code: 'SI',
+    alpha3Code: 'SVN',
+    numericCode: '705'
+  },
+  {
+    name: 'Islas Salomón',
+    alpha2Code: 'SB',
+    alpha3Code: 'SLB',
+    numericCode: '090'
+  },
+  {
+    name: 'Somalia',
+    alpha2Code: 'SO',
+    alpha3Code: 'SOM',
+    numericCode: '706'
+  },
+  {
+    name: 'Sudáfrica',
+    alpha2Code: 'ZA',
+    alpha3Code: 'ZAF',
+    numericCode: '710'
+  },
+  {
+    name: 'Sudán del Sur',
+    alpha2Code: 'SS',
+    alpha3Code: 'SSD',
+    numericCode: '728'
+  },
+  {
+    name: 'España',
+    alpha2Code: 'ES',
+    alpha3Code: 'ESP',
+    numericCode: '724'
+  },
+  {
+    name: 'Sri Lanka',
+    alpha2Code: 'LK',
+    alpha3Code: 'LKA',
+    numericCode: '144'
+  },
+  {
+    name: 'Sudán',
+    alpha2Code: 'SD',
+    alpha3Code: 'SDN',
+    numericCode: '729'
+  },
+  {
+    name: 'Surinam',
+    alpha2Code: 'SR',
+    alpha3Code: 'SUR',
+    numericCode: '740'
+  },
+  {
+    name: 'Suecia',
+    alpha2Code: 'SE',
+    alpha3Code: 'SWE',
+    numericCode: '752'
+  },
+  {
+    name: 'Suiza',
+    alpha2Code: 'CH',
+    alpha3Code: 'CHE',
+    numericCode: '756'
+  },
+  {
+    name: 'República Árabe Siria',
+    alpha2Code: 'SY',
+    alpha3Code: 'SYR',
+    numericCode: '760'
+  },
+  {
+    name: 'Taiwán',
+    alpha2Code: 'TW',
+    alpha3Code: 'TWN',
+    numericCode: '158'
+  },
+  {
+    name: 'Tayikistán',
+    alpha2Code: 'TJ',
+    alpha3Code: 'TJK',
+    numericCode: '762'
+  },
+  {
+    name: 'Tanzania',
+    alpha2Code: 'TZ',
+    alpha3Code: 'TZA',
+    numericCode: '834'
+  },
+  {
+    name: 'Tailandia',
+    alpha2Code: 'TH',
+    alpha3Code: 'THA',
+    numericCode: '764'
+  },
+  {
+    name: 'Timor-Leste',
+    alpha2Code: 'TL',
+    alpha3Code: 'TLS',
+    numericCode: '626'
+  },
+  {
+    name: 'Togo',
+    alpha2Code: 'TG',
+    alpha3Code: 'TGO',
+    numericCode: '768'
+  },
+  {
     name: 'Tonga',
     alpha2Code: 'TO',
     alpha3Code: 'TON',
     numericCode: '776'
   },
-    {
-      name: 'Trinidad y Tobago',
-      alpha2Code: 'TT',
-      alpha3Code: 'TTO',
-      numericCode: '780'
-    },
-    {
-      name: 'Túnez',
-      alpha2Code: 'TN',
-      alpha3Code: 'TUN',
-      numericCode: '788'
-    },
-    {
-      name: 'Turquía',
-      alpha2Code: 'TR',
-      alpha3Code: 'TUR',
-      numericCode: '792'
-    },
-    {
-      name: 'Turkmenistán',
-      alpha2Code: 'TM',
-      alpha3Code: 'TKM',
-      numericCode: '795'
-    },
-    {
-      name: 'Tuvalu',
-      alpha2Code: 'TV',
-      alpha3Code: 'TUV',
-      numericCode: '798'
-    },
-    {
-      name: 'Uganda',
-      alpha2Code: 'UG',
-      alpha3Code: 'UGA',
-      numericCode: '800'
-    },
-    {
-      name: 'Ucrania',
-      alpha2Code: 'UA',
-      alpha3Code: 'UKR',
-      numericCode: '804'
-    },
-    {
-      name: 'Emiratos Árabes Unidos',
-      alpha2Code: 'AE',
-      alpha3Code: 'SON',
-      numericCode: '784'
-    },
-    {
-      name: 'Reino Unido',
-      alpha2Code: 'GB',
-      alpha3Code: 'GBR',
-      numericCode: '826'
-    },
-    {
-      name: 'Estados Unidos de América',
-      alpha2Code: 'US',
-      alpha3Code: 'Estados Unidos',
-      numericCode: '840'
-    },
-    {
-      name: 'Uruguay',
-      alpha2Code: 'UY',
-      alpha3Code: 'URY',
-      numericCode: '858'
-    },
-    {
-      name: 'Uzbekistán',
-      alpha2Code: 'UZ',
-      alpha3Code: 'UZB',
-      numericCode: '860'
-    },
-    {
-      name: 'Vanuatu',
-      alpha2Code: 'VU',
-      alpha3Code: 'VUT',
-      numericCode: '548'
-    },
-    {
-      name: 'Venezuela',
-      alpha2Code: 'VE',
-      alpha3Code: 'VEN',
-      numericCode: '862'
-    },
-    {
-      name: 'Vietnam',
-      alpha2Code: 'VN',
-      alpha3Code: 'VNM',
-      numericCode: '704'
-    },
-    {
-      name: 'Yemen',
-      alpha2Code: 'YE',
-      alpha3Code: 'YEM',
-      numericCode: '887'
-    },
-    {
-      name: 'Zambia',
-      alpha2Code: 'ZM',
-      alpha3Code: 'ZMB',
-      numericCode: '894'
-    },
-    {
-      name: 'Zimbabwe',
-      alpha2Code: 'ZW',
-      alpha3Code: 'ZWE',
-      numericCode: '716'
-    }
-  ]
-;
+  {
+    name: 'Trinidad y Tobago',
+    alpha2Code: 'TT',
+    alpha3Code: 'TTO',
+    numericCode: '780'
+  },
+  {
+    name: 'Túnez',
+    alpha2Code: 'TN',
+    alpha3Code: 'TUN',
+    numericCode: '788'
+  },
+  {
+    name: 'Turquía',
+    alpha2Code: 'TR',
+    alpha3Code: 'TUR',
+    numericCode: '792'
+  },
+  {
+    name: 'Turkmenistán',
+    alpha2Code: 'TM',
+    alpha3Code: 'TKM',
+    numericCode: '795'
+  },
+  {
+    name: 'Tuvalu',
+    alpha2Code: 'TV',
+    alpha3Code: 'TUV',
+    numericCode: '798'
+  },
+  {
+    name: 'Uganda',
+    alpha2Code: 'UG',
+    alpha3Code: 'UGA',
+    numericCode: '800'
+  },
+  {
+    name: 'Ucrania',
+    alpha2Code: 'UA',
+    alpha3Code: 'UKR',
+    numericCode: '804'
+  },
+  {
+    name: 'Emiratos Árabes Unidos',
+    alpha2Code: 'AE',
+    alpha3Code: 'SON',
+    numericCode: '784'
+  },
+  {
+    name: 'Reino Unido',
+    alpha2Code: 'GB',
+    alpha3Code: 'GBR',
+    numericCode: '826'
+  },
+  {
+    name: 'Estados Unidos de América',
+    alpha2Code: 'US',
+    alpha3Code: 'Estados Unidos',
+    numericCode: '840'
+  },
+  {
+    name: 'Uruguay',
+    alpha2Code: 'UY',
+    alpha3Code: 'URY',
+    numericCode: '858'
+  },
+  {
+    name: 'Uzbekistán',
+    alpha2Code: 'UZ',
+    alpha3Code: 'UZB',
+    numericCode: '860'
+  },
+  {
+    name: 'Vanuatu',
+    alpha2Code: 'VU',
+    alpha3Code: 'VUT',
+    numericCode: '548'
+  },
+  {
+    name: 'Venezuela',
+    alpha2Code: 'VE',
+    alpha3Code: 'VEN',
+    numericCode: '862'
+  },
+  {
+    name: 'Vietnam',
+    alpha2Code: 'VN',
+    alpha3Code: 'VNM',
+    numericCode: '704'
+  },
+  {
+    name: 'Yemen',
+    alpha2Code: 'YE',
+    alpha3Code: 'YEM',
+    numericCode: '887'
+  },
+  {
+    name: 'Zambia',
+    alpha2Code: 'ZM',
+    alpha3Code: 'ZMB',
+    numericCode: '894'
+  },
+  {
+    name: 'Zimbabwe',
+    alpha2Code: 'ZW',
+    alpha3Code: 'ZWE',
+    numericCode: '716'
+  }
+];

--- a/projects/angular-material-extensions/select-country/src/lib/i18n/fr.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/i18n/fr.ts
@@ -1,1218 +1,1222 @@
-import {Country} from '../mat-select-country.component';
+import { Country } from '../mat-select-country.component';
 
-export const COUNTRIES_DB_FR: Country[] =
-  [
-    {
-      name: 'Afghanistan',
-      alpha2Code: 'AF',
-      alpha3Code: 'AFG',
-      numericCode: '004'
-    },
-    {
-      name: 'Albanie',
-      alpha2Code: 'AL',
-      alpha3Code: 'ALB',
-      numericCode: '008'
-    }, {
+export const COUNTRIES_DB_FR: Country[] = [
+  {
+    name: 'Afghanistan',
+    alpha2Code: 'AF',
+    alpha3Code: 'AFG',
+    numericCode: '004'
+  },
+  {
+    name: 'Albanie',
+    alpha2Code: 'AL',
+    alpha3Code: 'ALB',
+    numericCode: '008'
+  },
+  {
     name: 'Algérie',
     alpha2Code: 'DZ',
     alpha3Code: 'DZA',
     numericCode: '012'
   },
-    {
-      name: 'Samoa américaines',
-      alpha2Code: 'AS',
-      alpha3Code: 'ASM',
-      numericCode: '016'
-    },
-    {
-      name: 'Andorre',
-      alpha2Code: 'AD',
-      alpha3Code: 'ET',
-      numericCode: '020'
-    },
-    {
-      name: 'Angola',
-      alpha2Code: 'AO',
-      alpha3Code: 'AGO',
-      numericCode: '024'
-    },
-    {
-      name: 'Antigua-et-Barbuda',
-      alpha2Code: 'AG',
-      alpha3Code: 'ATG',
-      numericCode: '028'
-    },
-    {
-      name: 'Argentine',
-      alpha2Code: 'AR',
-      alpha3Code: 'ARG',
-      numericCode: '032'
-    },
-    {
-      name: 'Arménie',
-      alpha2Code: 'AM',
-      alpha3Code: 'ARM',
-      numericCode: '051'
-    },
-    {
-      name: 'Australie',
-      alpha2Code: 'AU',
-      alpha3Code: 'AUS',
-      numericCode: '036'
-    },
-    {
-      name: 'Autriche',
-      alpha2Code: 'AT',
-      alpha3Code: 'AUT',
-      numericCode: '040'
-    },
-    {
-      name: 'Azerbaïdjan',
-      alpha2Code: 'AZ',
-      alpha3Code: 'AZE',
-      numericCode: '031'
-    },
-    {
-      name: 'Bahamas',
-      alpha2Code: 'BS',
-      alpha3Code: 'BHS',
-      numericCode: '044'
-    },
-    {
-      name: 'Bahreïn',
-      alpha2Code: 'BH',
-      alpha3Code: 'BHR',
-      numericCode: '048'
-    },
-    {
-      name: 'Bangladesh',
-      alpha2Code: 'BD',
-      alpha3Code: 'BGD',
-      numericCode: '050'
-    },
-    {
-      name: 'Barbados',
-      alpha2Code: 'BB',
-      alpha3Code: 'BRB',
-      numericCode: '052'
-    }, {
+  {
+    name: 'Samoa américaines',
+    alpha2Code: 'AS',
+    alpha3Code: 'ASM',
+    numericCode: '016'
+  },
+  {
+    name: 'Andorre',
+    alpha2Code: 'AD',
+    alpha3Code: 'ET',
+    numericCode: '020'
+  },
+  {
+    name: 'Angola',
+    alpha2Code: 'AO',
+    alpha3Code: 'AGO',
+    numericCode: '024'
+  },
+  {
+    name: 'Antigua-et-Barbuda',
+    alpha2Code: 'AG',
+    alpha3Code: 'ATG',
+    numericCode: '028'
+  },
+  {
+    name: 'Argentine',
+    alpha2Code: 'AR',
+    alpha3Code: 'ARG',
+    numericCode: '032'
+  },
+  {
+    name: 'Arménie',
+    alpha2Code: 'AM',
+    alpha3Code: 'ARM',
+    numericCode: '051'
+  },
+  {
+    name: 'Australie',
+    alpha2Code: 'AU',
+    alpha3Code: 'AUS',
+    numericCode: '036'
+  },
+  {
+    name: 'Autriche',
+    alpha2Code: 'AT',
+    alpha3Code: 'AUT',
+    numericCode: '040'
+  },
+  {
+    name: 'Azerbaïdjan',
+    alpha2Code: 'AZ',
+    alpha3Code: 'AZE',
+    numericCode: '031'
+  },
+  {
+    name: 'Bahamas',
+    alpha2Code: 'BS',
+    alpha3Code: 'BHS',
+    numericCode: '044'
+  },
+  {
+    name: 'Bahreïn',
+    alpha2Code: 'BH',
+    alpha3Code: 'BHR',
+    numericCode: '048'
+  },
+  {
+    name: 'Bangladesh',
+    alpha2Code: 'BD',
+    alpha3Code: 'BGD',
+    numericCode: '050'
+  },
+  {
+    name: 'Barbados',
+    alpha2Code: 'BB',
+    alpha3Code: 'BRB',
+    numericCode: '052'
+  },
+  {
     name: 'Belarus',
-    alpha2Code: 'PAR',
+    alpha2Code: 'BY',
     alpha3Code: 'BLR',
     numericCode: '112'
   },
-    {
-      name: 'Belgique',
-      alpha2Code: 'BE',
-      alpha3Code: 'BEL',
-      numericCode: '056'
-    },
-    {
-      name: 'Belize',
-      alpha2Code: 'BZ',
-      alpha3Code: 'BLZ',
-      numericCode: '084'
-    },
-    {
-      name: 'Bénin',
-      alpha2Code: 'BJ',
-      alpha3Code: 'BEN',
-      numericCode: '204'
-    },
-    {
-      name: 'Bermuda',
-      alpha2Code: 'BM',
-      alpha3Code: 'BMU',
-      numericCode: '060'
-    },
-    {
-      name: 'Bhoutan',
-      alpha2Code: 'BT',
-      alpha3Code: 'BTN',
-      numericCode: '064'
-    },
-    {
-      name: 'Bolivie',
-      alpha2Code: 'BO',
-      alpha3Code: 'BOL',
-      numericCode: '068'
-    },
-    {
-      name: 'Bonaire, Saint-Eustache et Saba',
-      alpha2Code: 'BQ',
-      alpha3Code: 'BES',
-      numericCode: '535'
-    },
-    {
-      name: 'Bosnie-Herzégovine',
-      alpha2Code: 'BA',
-      alpha3Code: 'BIH',
-      numericCode: '070'
-    },
-    {
-      name: 'Botswana',
-      alpha2Code: 'BW',
-      alpha3Code: 'BWA',
-      numericCode: '072'
-    },
-    {
-      name: 'Île Bouvet',
-      alpha2Code: 'BV',
-      alpha3Code: 'BVT',
-      numericCode: '074'
-    },
-    {
-      name: 'Brésil',
-      alpha2Code: 'BR',
-      alpha3Code: 'BRA',
-      numericCode: '076'
-    },
-    {
-      name: 'Brunei',
-      alpha2Code: 'BN',
-      alpha3Code: 'BRN',
-      numericCode: '096'
-    },
-    {
-      name: 'Bulgarie',
-      alpha2Code: 'BG',
-      alpha3Code: 'BGR',
-      numericCode: '100'
-    },
-    {
-      name: 'Burkina Faso',
-      alpha2Code: 'BF',
-      alpha3Code: 'BFA',
-      numericCode: '854'
-    },
-    {
-      name: 'Burundi',
-      alpha2Code: 'BI',
-      alpha3Code: 'BDI',
-      numericCode: '108'
-    },
-    {
-      name: 'Cabo Verde',
-      alpha2Code: 'CV',
-      alpha3Code: 'CPV',
-      numericCode: '132'
-    },
-    {
-      name: 'Cambodge',
-      alpha2Code: 'KH',
-      alpha3Code: 'KHM',
-      numericCode: '116'
-    },
-    {
-      name: 'Cameroun',
-      alpha2Code: 'CM',
-      alpha3Code: 'CMR',
-      numericCode: '120'
-    },
-    {
-      name: 'Canada',
-      alpha2Code: 'CA',
-      alpha3Code: 'CAN',
-      numericCode: '124'
-    },
-    {
-      name: 'République centrafricaine',
-      alpha2Code: 'CF',
-      alpha3Code: 'CAF',
-      numericCode: '140'
-    },
-    {
-      name: 'Chad',
-      alpha2Code: 'TD',
-      alpha3Code: 'TCD',
-      numericCode: '148'
-    },
-    {
-      name: 'Chili',
-      alpha2Code: 'CL',
-      alpha3Code: 'CHL',
-      numericCode: '152'
-    },
-    {
-      name: 'Chine',
-      alpha2Code: 'CN',
-      alpha3Code: 'CHN',
-      numericCode: '156'
-    },
-    {
-      name: 'Colombie',
-      alpha2Code: 'CO',
-      alpha3Code: 'COL',
-      numericCode: '170'
-    },
-    {
-      name: 'Congo (République démocratique du)',
-      alpha2Code: 'CD',
-      alpha3Code: 'COD',
-      numericCode: '180'
-    },
-    {
-      name: 'Congo (République du)',
-      alpha2Code: 'CG',
-      alpha3Code: 'COG',
-      numericCode: '178'
-    },
-    {
-      name: 'Costa Rica',
-      alpha2Code: 'CR',
-      alpha3Code: 'CRI',
-      numericCode: '188'
-    },
-    {
-      name: 'Croatie',
-      alpha2Code: 'HR',
-      alpha3Code: 'HRV',
-      numericCode: '191'
-    },
-    {
-      name: 'Cuba',
-      alpha2Code: 'CU',
-      alpha3Code: 'CUB',
-      numericCode: '192'
-    }, {
+  {
+    name: 'Belgique',
+    alpha2Code: 'BE',
+    alpha3Code: 'BEL',
+    numericCode: '056'
+  },
+  {
+    name: 'Belize',
+    alpha2Code: 'BZ',
+    alpha3Code: 'BLZ',
+    numericCode: '084'
+  },
+  {
+    name: 'Bénin',
+    alpha2Code: 'BJ',
+    alpha3Code: 'BEN',
+    numericCode: '204'
+  },
+  {
+    name: 'Bermuda',
+    alpha2Code: 'BM',
+    alpha3Code: 'BMU',
+    numericCode: '060'
+  },
+  {
+    name: 'Bhoutan',
+    alpha2Code: 'BT',
+    alpha3Code: 'BTN',
+    numericCode: '064'
+  },
+  {
+    name: 'Bolivie',
+    alpha2Code: 'BO',
+    alpha3Code: 'BOL',
+    numericCode: '068'
+  },
+  {
+    name: 'Bonaire, Saint-Eustache et Saba',
+    alpha2Code: 'BQ',
+    alpha3Code: 'BES',
+    numericCode: '535'
+  },
+  {
+    name: 'Bosnie-Herzégovine',
+    alpha2Code: 'BA',
+    alpha3Code: 'BIH',
+    numericCode: '070'
+  },
+  {
+    name: 'Botswana',
+    alpha2Code: 'BW',
+    alpha3Code: 'BWA',
+    numericCode: '072'
+  },
+  {
+    name: 'Île Bouvet',
+    alpha2Code: 'BV',
+    alpha3Code: 'BVT',
+    numericCode: '074'
+  },
+  {
+    name: 'Brésil',
+    alpha2Code: 'BR',
+    alpha3Code: 'BRA',
+    numericCode: '076'
+  },
+  {
+    name: 'Brunei',
+    alpha2Code: 'BN',
+    alpha3Code: 'BRN',
+    numericCode: '096'
+  },
+  {
+    name: 'Bulgarie',
+    alpha2Code: 'BG',
+    alpha3Code: 'BGR',
+    numericCode: '100'
+  },
+  {
+    name: 'Burkina Faso',
+    alpha2Code: 'BF',
+    alpha3Code: 'BFA',
+    numericCode: '854'
+  },
+  {
+    name: 'Burundi',
+    alpha2Code: 'BI',
+    alpha3Code: 'BDI',
+    numericCode: '108'
+  },
+  {
+    name: 'Cabo Verde',
+    alpha2Code: 'CV',
+    alpha3Code: 'CPV',
+    numericCode: '132'
+  },
+  {
+    name: 'Cambodge',
+    alpha2Code: 'KH',
+    alpha3Code: 'KHM',
+    numericCode: '116'
+  },
+  {
+    name: 'Cameroun',
+    alpha2Code: 'CM',
+    alpha3Code: 'CMR',
+    numericCode: '120'
+  },
+  {
+    name: 'Canada',
+    alpha2Code: 'CA',
+    alpha3Code: 'CAN',
+    numericCode: '124'
+  },
+  {
+    name: 'République centrafricaine',
+    alpha2Code: 'CF',
+    alpha3Code: 'CAF',
+    numericCode: '140'
+  },
+  {
+    name: 'Chad',
+    alpha2Code: 'TD',
+    alpha3Code: 'TCD',
+    numericCode: '148'
+  },
+  {
+    name: 'Chili',
+    alpha2Code: 'CL',
+    alpha3Code: 'CHL',
+    numericCode: '152'
+  },
+  {
+    name: 'Chine',
+    alpha2Code: 'CN',
+    alpha3Code: 'CHN',
+    numericCode: '156'
+  },
+  {
+    name: 'Colombie',
+    alpha2Code: 'CO',
+    alpha3Code: 'COL',
+    numericCode: '170'
+  },
+  {
+    name: 'Congo (République démocratique du)',
+    alpha2Code: 'CD',
+    alpha3Code: 'COD',
+    numericCode: '180'
+  },
+  {
+    name: 'Congo (République du)',
+    alpha2Code: 'CG',
+    alpha3Code: 'COG',
+    numericCode: '178'
+  },
+  {
+    name: 'Costa Rica',
+    alpha2Code: 'CR',
+    alpha3Code: 'CRI',
+    numericCode: '188'
+  },
+  {
+    name: 'Croatie',
+    alpha2Code: 'HR',
+    alpha3Code: 'HRV',
+    numericCode: '191'
+  },
+  {
+    name: 'Cuba',
+    alpha2Code: 'CU',
+    alpha3Code: 'CUB',
+    numericCode: '192'
+  },
+  {
     name: 'Chypre',
     alpha2Code: 'CY',
     alpha3Code: 'CYP',
     numericCode: '196'
   },
-    {
-      name: 'Czechia',
-      alpha2Code: 'CZ',
-      alpha3Code: 'CZE',
-      numericCode: '203'
-    },
-    {
-      name: 'Côte d \' Ivoire ',
-      alpha2Code: 'CI',
-      alpha3Code: 'CIV',
-      numericCode: '384'
-    },
-    {
-      name: 'Danemark',
-      alpha2Code: 'DK',
-      alpha3Code: 'DNK',
-      numericCode: '208'
-    },
-    {
-      name: 'Djibouti',
-      alpha2Code: 'DJ',
-      alpha3Code: 'DJI',
-      numericCode: '262'
-    },
-    {
-      name: 'Dominique',
-      alpha2Code: 'DM',
-      alpha3Code: 'DMA',
-      numericCode: '212'
-    },
-    {
-      name: 'République dominicaine',
-      alpha2Code: 'DO',
-      alpha3Code: 'DOM',
-      numericCode: '214'
-    },
-    {
-      name: 'Equateur',
-      alpha2Code: 'EC',
-      alpha3Code: 'ECU',
-      numericCode: '218'
-    },
-    {
-      name: 'Egypte',
-      alpha2Code: 'EG',
-      alpha3Code: 'EGY',
-      numericCode: '818'
-    },
-    {
-      name: 'El Salvador',
-      alpha2Code: 'SV',
-      alpha3Code: 'SLV',
-      numericCode: '222'
-    },
-    {
-      name: 'Guinée équatoriale',
-      alpha2Code: 'GQ',
-      alpha3Code: 'GNQ',
-      numericCode: '226'
-    },
-    {
-      name: 'Erythrée',
-      alpha2Code: 'ER',
-      alpha3Code: 'ERI',
-      numericCode: '232'
-    },
-    {
-      name: 'Estonie',
-      alpha2Code: 'EE',
-      alpha3Code: 'EST',
-      numericCode: '233'
-    },
-    {
-      name: 'Eswatini',
-      alpha2Code: 'SZ',
-      alpha3Code: 'SWZ',
-      numericCode: '748'
-    },
-    {
-      name: 'Ethiopie',
-      alpha2Code: 'ET',
-      alpha3Code: 'ETH',
-      numericCode: '231'
-    },
-    {
-      name: 'Fidji',
-      alpha2Code: 'FJ',
-      alpha3Code: 'FJI',
-      numericCode: '242'
-    },
-    {
-      name: 'Finlande',
-      alpha2Code: 'FI',
-      alpha3Code: 'FIN',
-      numericCode: '246'
-    },
-    {
-      name: 'France',
-      alpha2Code: 'FR',
-      alpha3Code: 'FRA',
-      numericCode: '250'
-    },
-    {
-      name: 'Gabon',
-      alpha2Code: 'GA',
-      alpha3Code: 'GAB',
-      numericCode: '266'
-    },
-    {
-      name: 'Gambie',
-      alpha2Code: 'GM',
-      alpha3Code: 'GMB',
-      numericCode: '270'
-    },
-    {
-      name: 'Géorgie',
-      alpha2Code: 'GE',
-      alpha3Code: 'GEO',
-      numericCode: '268'
-    },
-    {
-      name: 'Allemagne',
-      alpha2Code: 'DE',
-      alpha3Code: 'DEU',
-      numericCode: '276'
-    },
-    {
-      name: 'Ghana',
-      alpha2Code: 'GH',
-      alpha3Code: 'GHA',
-      numericCode: '288'
-    },
-    {
-      name: 'Grèce',
-      alpha2Code: 'GR',
-      alpha3Code: 'GRC',
-      numericCode: '300'
-    },
-    {
-      name: 'Groenland',
-      alpha2Code: 'GL',
-      alpha3Code: 'GRL',
-      numericCode: '304'
-    },
-    {
-      name: 'Guadeloupe',
-      alpha2Code: 'GP',
-      alpha3Code: 'GLP',
-      numericCode: '312'
-    },
-    {
-      name: 'Grenada',
-      alpha2Code: 'GD',
-      alpha3Code: 'GRD',
-      numericCode: '308'
-    },
-    {
-      name: 'Guatemala',
-      alpha2Code: 'GT',
-      alpha3Code: 'GTM',
-      numericCode: '320'
-    },
-    {
-      name: 'Guinée',
-      alpha2Code: 'GN',
-      alpha3Code: 'GIN',
-      numericCode: '324'
-    },
-    {
-      name: 'Guinée-Bissau',
-      alpha2Code: 'GW',
-      alpha3Code: 'GNB',
-      numericCode: '624'
-    },
-    {
-      name: 'Guyana',
-      alpha2Code: 'GY',
-      alpha3Code: 'GUY',
-      numericCode: '328'
-    },
-    {
-      name: 'Haïti',
-      alpha2Code: 'HT',
-      alpha3Code: 'HTI',
-      numericCode: '332'
-    },
-    {
-      name: 'Honduras',
-      alpha2Code: 'HN',
-      alpha3Code: 'HND',
-      numericCode: '340'
-    },
-    {
-      name: 'Hong Kong',
-      alpha2Code: 'HK',
-      alpha3Code: 'HKG',
-      numericCode: '344'
-    },
-    {
-      name: 'Hongrie',
-      alpha2Code: 'HU',
-      alpha3Code: 'HUN',
-      numericCode: '348'
-    },
-    {
-      name: 'Islande',
-      alpha2Code: 'EST',
-      alpha3Code: 'ISL',
-      numericCode: '352'
-    },
-    {
-      name: 'Inde',
-      alpha2Code: 'IN',
-      alpha3Code: 'IND',
-      numericCode: '356'
-    },
-    {
-      name: 'Indonésie',
-      alpha2Code: 'ID',
-      alpha3Code: 'IDN',
-      numericCode: '360'
-    },
-    {
-      name: 'Iran',
-      alpha2Code: 'IR',
-      alpha3Code: 'IRN',
-      numericCode: '364'
-    },
-    {
-      name: 'Iraq',
-      alpha2Code: 'IQ',
-      alpha3Code: 'IRQ',
-      numericCode: '368'
-    }, {
+  {
+    name: 'Czechia',
+    alpha2Code: 'CZ',
+    alpha3Code: 'CZE',
+    numericCode: '203'
+  },
+  {
+    name: "Côte d ' Ivoire ",
+    alpha2Code: 'CI',
+    alpha3Code: 'CIV',
+    numericCode: '384'
+  },
+  {
+    name: 'Danemark',
+    alpha2Code: 'DK',
+    alpha3Code: 'DNK',
+    numericCode: '208'
+  },
+  {
+    name: 'Djibouti',
+    alpha2Code: 'DJ',
+    alpha3Code: 'DJI',
+    numericCode: '262'
+  },
+  {
+    name: 'Dominique',
+    alpha2Code: 'DM',
+    alpha3Code: 'DMA',
+    numericCode: '212'
+  },
+  {
+    name: 'République dominicaine',
+    alpha2Code: 'DO',
+    alpha3Code: 'DOM',
+    numericCode: '214'
+  },
+  {
+    name: 'Equateur',
+    alpha2Code: 'EC',
+    alpha3Code: 'ECU',
+    numericCode: '218'
+  },
+  {
+    name: 'Egypte',
+    alpha2Code: 'EG',
+    alpha3Code: 'EGY',
+    numericCode: '818'
+  },
+  {
+    name: 'El Salvador',
+    alpha2Code: 'SV',
+    alpha3Code: 'SLV',
+    numericCode: '222'
+  },
+  {
+    name: 'Guinée équatoriale',
+    alpha2Code: 'GQ',
+    alpha3Code: 'GNQ',
+    numericCode: '226'
+  },
+  {
+    name: 'Erythrée',
+    alpha2Code: 'ER',
+    alpha3Code: 'ERI',
+    numericCode: '232'
+  },
+  {
+    name: 'Estonie',
+    alpha2Code: 'EE',
+    alpha3Code: 'EST',
+    numericCode: '233'
+  },
+  {
+    name: 'Eswatini',
+    alpha2Code: 'SZ',
+    alpha3Code: 'SWZ',
+    numericCode: '748'
+  },
+  {
+    name: 'Ethiopie',
+    alpha2Code: 'ET',
+    alpha3Code: 'ETH',
+    numericCode: '231'
+  },
+  {
+    name: 'Fidji',
+    alpha2Code: 'FJ',
+    alpha3Code: 'FJI',
+    numericCode: '242'
+  },
+  {
+    name: 'Finlande',
+    alpha2Code: 'FI',
+    alpha3Code: 'FIN',
+    numericCode: '246'
+  },
+  {
+    name: 'France',
+    alpha2Code: 'FR',
+    alpha3Code: 'FRA',
+    numericCode: '250'
+  },
+  {
+    name: 'Gabon',
+    alpha2Code: 'GA',
+    alpha3Code: 'GAB',
+    numericCode: '266'
+  },
+  {
+    name: 'Gambie',
+    alpha2Code: 'GM',
+    alpha3Code: 'GMB',
+    numericCode: '270'
+  },
+  {
+    name: 'Géorgie',
+    alpha2Code: 'GE',
+    alpha3Code: 'GEO',
+    numericCode: '268'
+  },
+  {
+    name: 'Allemagne',
+    alpha2Code: 'DE',
+    alpha3Code: 'DEU',
+    numericCode: '276'
+  },
+  {
+    name: 'Ghana',
+    alpha2Code: 'GH',
+    alpha3Code: 'GHA',
+    numericCode: '288'
+  },
+  {
+    name: 'Grèce',
+    alpha2Code: 'GR',
+    alpha3Code: 'GRC',
+    numericCode: '300'
+  },
+  {
+    name: 'Groenland',
+    alpha2Code: 'GL',
+    alpha3Code: 'GRL',
+    numericCode: '304'
+  },
+  {
+    name: 'Guadeloupe',
+    alpha2Code: 'GP',
+    alpha3Code: 'GLP',
+    numericCode: '312'
+  },
+  {
+    name: 'Grenada',
+    alpha2Code: 'GD',
+    alpha3Code: 'GRD',
+    numericCode: '308'
+  },
+  {
+    name: 'Guatemala',
+    alpha2Code: 'GT',
+    alpha3Code: 'GTM',
+    numericCode: '320'
+  },
+  {
+    name: 'Guinée',
+    alpha2Code: 'GN',
+    alpha3Code: 'GIN',
+    numericCode: '324'
+  },
+  {
+    name: 'Guinée-Bissau',
+    alpha2Code: 'GW',
+    alpha3Code: 'GNB',
+    numericCode: '624'
+  },
+  {
+    name: 'Guyana',
+    alpha2Code: 'GY',
+    alpha3Code: 'GUY',
+    numericCode: '328'
+  },
+  {
+    name: 'Haïti',
+    alpha2Code: 'HT',
+    alpha3Code: 'HTI',
+    numericCode: '332'
+  },
+  {
+    name: 'Honduras',
+    alpha2Code: 'HN',
+    alpha3Code: 'HND',
+    numericCode: '340'
+  },
+  {
+    name: 'Hong Kong',
+    alpha2Code: 'HK',
+    alpha3Code: 'HKG',
+    numericCode: '344'
+  },
+  {
+    name: 'Hongrie',
+    alpha2Code: 'HU',
+    alpha3Code: 'HUN',
+    numericCode: '348'
+  },
+  {
+    name: 'Islande',
+    alpha2Code: 'IS',
+    alpha3Code: 'ISL',
+    numericCode: '352'
+  },
+  {
+    name: 'Inde',
+    alpha2Code: 'IN',
+    alpha3Code: 'IND',
+    numericCode: '356'
+  },
+  {
+    name: 'Indonésie',
+    alpha2Code: 'ID',
+    alpha3Code: 'IDN',
+    numericCode: '360'
+  },
+  {
+    name: 'Iran',
+    alpha2Code: 'IR',
+    alpha3Code: 'IRN',
+    numericCode: '364'
+  },
+  {
+    name: 'Iraq',
+    alpha2Code: 'IQ',
+    alpha3Code: 'IRQ',
+    numericCode: '368'
+  },
+  {
     name: 'Irlande',
     alpha2Code: 'IE',
     alpha3Code: 'IRL',
     numericCode: '372'
   },
-    {
-      name: 'Israël',
-      alpha2Code: 'IL',
-      alpha3Code: 'ISR',
-      numericCode: '376'
-    },
-    {
-      name: 'Italie',
-      alpha2Code: 'IT',
-      alpha3Code: 'ITA',
-      numericCode: '380'
-    },
-    {
-      name: 'Jamaica',
-      alpha2Code: 'JM',
-      alpha3Code: 'JAM',
-      numericCode: '388'
-    },
-    {
-      name: 'Japon',
-      alpha2Code: 'JP',
-      alpha3Code: 'JPN',
-      numericCode: '392'
-    },
-    {
-      name: 'Jersey',
-      alpha2Code: 'JE',
-      alpha3Code: 'JEY',
-      numericCode: '832'
-    },
-    {
-      name: 'Jordan',
-      alpha2Code: 'JO',
-      alpha3Code: 'JOR',
-      numericCode: '400'
-    },
-    {
-      name: 'Kazakhstan',
-      alpha2Code: 'KZ',
-      alpha3Code: 'KAZ',
-      numericCode: '398'
-    },
-    {
-      name: 'Kenya',
-      alpha2Code: 'KE',
-      alpha3Code: 'KEN',
-      numericCode: '404'
-    },
-    {
-      name: 'Kiribati',
-      alpha2Code: 'KI',
-      alpha3Code: 'KIR',
-      numericCode: '296'
-    },
-    {
-      name: 'Corée (République populaire démocratique de)',
-      alpha2Code: 'KP',
-      alpha3Code: 'PRK',
-      numericCode: '408'
-    },
-    {
-      name: 'Corée (République de) \ t',
-      alpha2Code: 'KR',
-      alpha3Code: 'KOR',
-      numericCode: '410'
-    },
-    {
-      name: 'Koweït',
-      alpha2Code: 'KW',
-      alpha3Code: 'KWT',
-      numericCode: '414'
-    },
-    {
-      name: 'Kirghizistan',
-      alpha2Code: 'KG',
-      alpha3Code: 'KGZ',
-      numericCode: '417'
-    },
-    {
-      name: 'Laos',
-      alpha2Code: 'LA',
-      alpha3Code: 'LAO',
-      numericCode: '418'
-    },
-    {
-      name: 'Lettonie',
-      alpha2Code: 'LV',
-      alpha3Code: 'LVA',
-      numericCode: '428'
-    },
-    {
-      name: 'Liban',
-      alpha2Code: 'LB',
-      alpha3Code: 'LBN',
-      numericCode: '422'
-    },
-    {
-      name: 'Lesotho',
-      alpha2Code: 'LS',
-      alpha3Code: 'LSO',
-      numericCode: '426'
-    },
-    {
-      name: 'Liberia',
-      alpha2Code: 'LR',
-      alpha3Code: 'LBR',
-      numericCode: '430'
-    },
-    {
-      name: 'Libye',
-      alpha2Code: 'LY',
-      alpha3Code: 'LBY',
-      numericCode: '434'
-    },
-    {
-      name: 'Liechtenstein',
-      alpha2Code: 'LI',
-      alpha3Code: 'LIE',
-      numericCode: '438'
-    },
-    {
-      name: 'Lituanie',
-      alpha2Code: 'LT',
-      alpha3Code: 'LTU',
-      numericCode: '440'
-    },
-    {
-      name: 'Luxembourg',
-      alpha2Code: 'LU',
-      alpha3Code: 'LUX',
-      numericCode: '442'
-    },
-    {
-      name: 'Macao',
-      alpha2Code: 'MO',
-      alpha3Code: 'MAC',
-      numericCode: '446'
-    },
-    {
-      name: 'Madagascar',
-      alpha2Code: 'MG',
-      alpha3Code: 'MDG',
-      numericCode: '450'
-    },
-    {
-      name: 'Malawi',
-      alpha2Code: 'MW',
-      alpha3Code: 'MWI',
-      numericCode: '454'
-    },
-    {
-      name: 'Malaisie',
-      alpha2Code: 'MON',
-      alpha3Code: 'MYS',
-      numericCode: '458'
-    },
-    {
-      name: 'Maldives',
-      alpha2Code: 'MV',
-      alpha3Code: 'MDV',
-      numericCode: '462'
-    },
-    {
-      name: 'Mali',
-      alpha2Code: 'ML',
-      alpha3Code: 'MLI',
-      numericCode: '466'
-    },
-    {
-      name: 'Malte',
-      alpha2Code: 'MT',
-      alpha3Code: 'MLT',
-      numericCode: '470'
-    },
-    {
-      name: 'Mauritania',
-      alpha2Code: 'MR',
-      alpha3Code: 'MRT',
-      numericCode: '478'
-    },
-    {
-      name: 'Mauritius',
-      alpha2Code: 'MU',
-      alpha3Code: 'MUS',
-      numericCode: '480'
-    },
-    {
-      name: 'Mexique',
-      alpha2Code: 'MX',
-      alpha3Code: 'MEX',
-      numericCode: '484'
-    },
-    {
-      name: 'Moldova',
-      alpha2Code: 'MD',
-      alpha3Code: 'MDA',
-      numericCode: '498'
-    },
-    {
-      name: 'Monaco',
-      alpha2Code: 'MC',
-      alpha3Code: 'MCO',
-      numericCode: '492'
-    },
-    {
-      name: 'Mongolie',
-      alpha2Code: 'MN',
-      alpha3Code: 'MNG',
-      numericCode: '496'
-    },
-    {
-      name: 'Monténégro',
-      alpha2Code: 'ME',
-      alpha3Code: 'MNE',
-      numericCode: '499'
-    },
-    {
-      name: 'Maroc',
-      alpha2Code: 'MA',
-      alpha3Code: 'MAR',
-      numericCode: '504'
-    }, {
+  {
+    name: 'Israël',
+    alpha2Code: 'IL',
+    alpha3Code: 'ISR',
+    numericCode: '376'
+  },
+  {
+    name: 'Italie',
+    alpha2Code: 'IT',
+    alpha3Code: 'ITA',
+    numericCode: '380'
+  },
+  {
+    name: 'Jamaica',
+    alpha2Code: 'JM',
+    alpha3Code: 'JAM',
+    numericCode: '388'
+  },
+  {
+    name: 'Japon',
+    alpha2Code: 'JP',
+    alpha3Code: 'JPN',
+    numericCode: '392'
+  },
+  {
+    name: 'Jersey',
+    alpha2Code: 'JE',
+    alpha3Code: 'JEY',
+    numericCode: '832'
+  },
+  {
+    name: 'Jordan',
+    alpha2Code: 'JO',
+    alpha3Code: 'JOR',
+    numericCode: '400'
+  },
+  {
+    name: 'Kazakhstan',
+    alpha2Code: 'KZ',
+    alpha3Code: 'KAZ',
+    numericCode: '398'
+  },
+  {
+    name: 'Kenya',
+    alpha2Code: 'KE',
+    alpha3Code: 'KEN',
+    numericCode: '404'
+  },
+  {
+    name: 'Kiribati',
+    alpha2Code: 'KI',
+    alpha3Code: 'KIR',
+    numericCode: '296'
+  },
+  {
+    name: 'Corée (République populaire démocratique de)',
+    alpha2Code: 'KP',
+    alpha3Code: 'PRK',
+    numericCode: '408'
+  },
+  {
+    name: 'Corée (République de)  t',
+    alpha2Code: 'KR',
+    alpha3Code: 'KOR',
+    numericCode: '410'
+  },
+  {
+    name: 'Koweït',
+    alpha2Code: 'KW',
+    alpha3Code: 'KWT',
+    numericCode: '414'
+  },
+  {
+    name: 'Kirghizistan',
+    alpha2Code: 'KG',
+    alpha3Code: 'KGZ',
+    numericCode: '417'
+  },
+  {
+    name: 'Laos',
+    alpha2Code: 'LA',
+    alpha3Code: 'LAO',
+    numericCode: '418'
+  },
+  {
+    name: 'Lettonie',
+    alpha2Code: 'LV',
+    alpha3Code: 'LVA',
+    numericCode: '428'
+  },
+  {
+    name: 'Liban',
+    alpha2Code: 'LB',
+    alpha3Code: 'LBN',
+    numericCode: '422'
+  },
+  {
+    name: 'Lesotho',
+    alpha2Code: 'LS',
+    alpha3Code: 'LSO',
+    numericCode: '426'
+  },
+  {
+    name: 'Liberia',
+    alpha2Code: 'LR',
+    alpha3Code: 'LBR',
+    numericCode: '430'
+  },
+  {
+    name: 'Libye',
+    alpha2Code: 'LY',
+    alpha3Code: 'LBY',
+    numericCode: '434'
+  },
+  {
+    name: 'Liechtenstein',
+    alpha2Code: 'LI',
+    alpha3Code: 'LIE',
+    numericCode: '438'
+  },
+  {
+    name: 'Lituanie',
+    alpha2Code: 'LT',
+    alpha3Code: 'LTU',
+    numericCode: '440'
+  },
+  {
+    name: 'Luxembourg',
+    alpha2Code: 'LU',
+    alpha3Code: 'LUX',
+    numericCode: '442'
+  },
+  {
+    name: 'Macao',
+    alpha2Code: 'MO',
+    alpha3Code: 'MAC',
+    numericCode: '446'
+  },
+  {
+    name: 'Madagascar',
+    alpha2Code: 'MG',
+    alpha3Code: 'MDG',
+    numericCode: '450'
+  },
+  {
+    name: 'Malawi',
+    alpha2Code: 'MW',
+    alpha3Code: 'MWI',
+    numericCode: '454'
+  },
+  {
+    name: 'Malaisie',
+    alpha2Code: 'MY',
+    alpha3Code: 'MYS',
+    numericCode: '458'
+  },
+  {
+    name: 'Maldives',
+    alpha2Code: 'MV',
+    alpha3Code: 'MDV',
+    numericCode: '462'
+  },
+  {
+    name: 'Mali',
+    alpha2Code: 'ML',
+    alpha3Code: 'MLI',
+    numericCode: '466'
+  },
+  {
+    name: 'Malte',
+    alpha2Code: 'MT',
+    alpha3Code: 'MLT',
+    numericCode: '470'
+  },
+  {
+    name: 'Mauritania',
+    alpha2Code: 'MR',
+    alpha3Code: 'MRT',
+    numericCode: '478'
+  },
+  {
+    name: 'Mauritius',
+    alpha2Code: 'MU',
+    alpha3Code: 'MUS',
+    numericCode: '480'
+  },
+  {
+    name: 'Mexique',
+    alpha2Code: 'MX',
+    alpha3Code: 'MEX',
+    numericCode: '484'
+  },
+  {
+    name: 'Moldova',
+    alpha2Code: 'MD',
+    alpha3Code: 'MDA',
+    numericCode: '498'
+  },
+  {
+    name: 'Monaco',
+    alpha2Code: 'MC',
+    alpha3Code: 'MCO',
+    numericCode: '492'
+  },
+  {
+    name: 'Mongolie',
+    alpha2Code: 'MN',
+    alpha3Code: 'MNG',
+    numericCode: '496'
+  },
+  {
+    name: 'Monténégro',
+    alpha2Code: 'ME',
+    alpha3Code: 'MNE',
+    numericCode: '499'
+  },
+  {
+    name: 'Maroc',
+    alpha2Code: 'MA',
+    alpha3Code: 'MAR',
+    numericCode: '504'
+  },
+  {
     name: 'Mozambique',
     alpha2Code: 'MZ',
     alpha3Code: 'MOZ',
     numericCode: '508'
   },
-    {
-      name: 'Myanmar',
-      alpha2Code: 'MM',
-      alpha3Code: 'MMR',
-      numericCode: '104'
-    },
-    {
-      name: 'Namibie',
-      alpha2Code: 'NA',
-      alpha3Code: 'NAM',
-      numericCode: '516'
-    },
-    {
-      name: 'Nauru',
-      alpha2Code: 'NR',
-      alpha3Code: 'NRU',
-      numericCode: '520'
-    },
-    {
-      name: 'Népal',
-      alpha2Code: 'NP',
-      alpha3Code: 'NPL',
-      numericCode: '524'
-    },
-    {
-      name: 'Pays-Bas',
-      alpha2Code: 'NL',
-      alpha3Code: 'NLD',
-      numericCode: '528'
-    },
-    {
-      name: 'Nouvelle Calédonie',
-      alpha2Code: 'NC',
-      alpha3Code: 'NCL',
-      numericCode: '540'
-    },
-    {
-      name: 'Nouvelle-Zélande',
-      alpha2Code: 'NZ',
-      alpha3Code: 'NZL',
-      numericCode: '554'
-    },
-    {
-      name: 'Nicaragua',
-      alpha2Code: 'NI',
-      alpha3Code: 'NIC',
-      numericCode: '558'
-    },
-    {
-      name: 'Niger',
-      alpha2Code: 'NE',
-      alpha3Code: 'NER',
-      numericCode: '562'
-    },
-    {
-      name: 'Nigeria',
-      alpha2Code: 'NG',
-      alpha3Code: 'NGA',
-      numericCode: '566'
-    },
-    {
-      name: 'Norvège',
-      alpha2Code: 'NON',
-      alpha3Code: 'NOR',
-      numericCode: '578'
-    },
-    {
-      name: 'Oman',
-      alpha2Code: 'OM',
-      alpha3Code: 'OMN',
-      numericCode: '512'
-    },
-    {
-      name: 'Pakistan',
-      alpha2Code: 'PK',
-      alpha3Code: 'PAK',
-      numericCode: '586'
-    },
-    {
-      name: 'Palau',
-      alpha2Code: 'PW',
-      alpha3Code: 'PLW',
-      numericCode: '585'
-    },
-    {
-      name: 'Palestine',
-      alpha2Code: 'PS',
-      alpha3Code: 'PSE',
-      numericCode: '275'
-    },
-    {
-      name: 'Panama',
-      alpha2Code: 'PA',
-      alpha3Code: 'PAN',
-      numericCode: '591'
-    },
-    {
-      name: 'Papouasie-Nouvelle-Guinée',
-      alpha2Code: 'PG',
-      alpha3Code: 'PNG',
-      numericCode: '598'
-    },
-    {
-      name: 'Paraguay',
-      alpha2Code: 'PY',
-      alpha3Code: 'PRY',
-      numericCode: '600'
-    },
-    {
-      name: 'Pérou',
-      alpha2Code: 'PE',
-      alpha3Code: 'PER',
-      numericCode: '604'
-    },
-    {
-      name: 'Philippines',
-      alpha2Code: 'PH',
-      alpha3Code: 'PHL',
-      numericCode: '608'
-    },
-    {
-      name: 'Pologne',
-      alpha2Code: 'PL',
-      alpha3Code: 'POL',
-      numericCode: '616'
-    },
-    {
-      name: 'Portugal',
-      alpha2Code: 'PT',
-      alpha3Code: 'PRT',
-      numericCode: '620'
-    },
-    {
-      name: 'Puerto Rico',
-      alpha2Code: 'PR',
-      alpha3Code: 'PRI',
-      numericCode: '630'
-    },
-    {
-      name: 'Qatar',
-      alpha2Code: 'QA',
-      alpha3Code: 'QAT',
-      numericCode: '634'
-    },
-    {
-      name: 'République de Macédoine du Nord',
-      alpha2Code: 'MK',
-      alpha3Code: 'MKD',
-      numericCode: '807'
-    },
-    {
-      name: 'Roumanie',
-      alpha2Code: 'RO',
-      alpha3Code: 'ROU',
-      numericCode: '642'
-    },
-    {
-      name: 'Fédération de Russie (la)',
-      alpha2Code: 'RU',
-      alpha3Code: 'RUS',
-      numericCode: '643'
-    },
-    {
-      name: 'Rwanda',
-      alpha2Code: 'RW',
-      alpha3Code: 'RWA',
-      numericCode: '646'
-    },
-    {
-      name: 'Saint Kitts et Nevis',
-      alpha2Code: 'KN',
-      alpha3Code: 'KNA',
-      numericCode: '659'
-    },
-    {
-      name: 'Sainte Lucie',
-      alpha2Code: 'LC',
-      alpha3Code: 'LCA',
-      numericCode: '662'
-    },
-    {
-      name: 'Saint-Vincent-et-les Grenadines',
-      alpha2Code: 'VC',
-      alpha3Code: 'VCT',
-      numericCode: '670'
-    },
-    {
-      name: 'Samoa',
-      alpha2Code: 'WS',
-      alpha3Code: 'WSM',
-      numericCode: '882'
-    },
-    {
-      name: 'Saint-Marin',
-      alpha2Code: 'SM',
-      alpha3Code: 'SMR',
-      numericCode: '674'
-    },
-    {
-      name: 'Sao Tomé-et-Principe',
-      alpha2Code: 'ST',
-      alpha3Code: 'STP',
-      numericCode: '678'
-    },
-    {
-      name: 'Arabie saoudite',
-      alpha2Code: 'SA',
-      alpha3Code: 'SAU',
-      numericCode: '682'
-    },
-    {
-      name: 'Sénégal',
-      alpha2Code: 'SN',
-      alpha3Code: 'SEN',
-      numericCode: '686'
-    },
-    {
-      name: 'Serbie',
-      alpha2Code: 'RS',
-      alpha3Code: 'SRB',
-      numericCode: '688'
-    },
-    {
-      name: 'Seychelles',
-      alpha2Code: 'SC',
-      alpha3Code: 'SYC',
-      numericCode: '690'
-    },
-    {
-      name: 'Sierra Leone',
-      alpha2Code: 'SL',
-      alpha3Code: 'SLE',
-      numericCode: '694'
-    }, {
+  {
+    name: 'Myanmar',
+    alpha2Code: 'MM',
+    alpha3Code: 'MMR',
+    numericCode: '104'
+  },
+  {
+    name: 'Namibie',
+    alpha2Code: 'NA',
+    alpha3Code: 'NAM',
+    numericCode: '516'
+  },
+  {
+    name: 'Nauru',
+    alpha2Code: 'NR',
+    alpha3Code: 'NRU',
+    numericCode: '520'
+  },
+  {
+    name: 'Népal',
+    alpha2Code: 'NP',
+    alpha3Code: 'NPL',
+    numericCode: '524'
+  },
+  {
+    name: 'Pays-Bas',
+    alpha2Code: 'NL',
+    alpha3Code: 'NLD',
+    numericCode: '528'
+  },
+  {
+    name: 'Nouvelle Calédonie',
+    alpha2Code: 'NC',
+    alpha3Code: 'NCL',
+    numericCode: '540'
+  },
+  {
+    name: 'Nouvelle-Zélande',
+    alpha2Code: 'NZ',
+    alpha3Code: 'NZL',
+    numericCode: '554'
+  },
+  {
+    name: 'Nicaragua',
+    alpha2Code: 'NI',
+    alpha3Code: 'NIC',
+    numericCode: '558'
+  },
+  {
+    name: 'Niger',
+    alpha2Code: 'NE',
+    alpha3Code: 'NER',
+    numericCode: '562'
+  },
+  {
+    name: 'Nigeria',
+    alpha2Code: 'NG',
+    alpha3Code: 'NGA',
+    numericCode: '566'
+  },
+  {
+    name: 'Norvège',
+    alpha2Code: 'NO',
+    alpha3Code: 'NOR',
+    numericCode: '578'
+  },
+  {
+    name: 'Oman',
+    alpha2Code: 'OM',
+    alpha3Code: 'OMN',
+    numericCode: '512'
+  },
+  {
+    name: 'Pakistan',
+    alpha2Code: 'PK',
+    alpha3Code: 'PAK',
+    numericCode: '586'
+  },
+  {
+    name: 'Palau',
+    alpha2Code: 'PW',
+    alpha3Code: 'PLW',
+    numericCode: '585'
+  },
+  {
+    name: 'Palestine',
+    alpha2Code: 'PS',
+    alpha3Code: 'PSE',
+    numericCode: '275'
+  },
+  {
+    name: 'Panama',
+    alpha2Code: 'PA',
+    alpha3Code: 'PAN',
+    numericCode: '591'
+  },
+  {
+    name: 'Papouasie-Nouvelle-Guinée',
+    alpha2Code: 'PG',
+    alpha3Code: 'PNG',
+    numericCode: '598'
+  },
+  {
+    name: 'Paraguay',
+    alpha2Code: 'PY',
+    alpha3Code: 'PRY',
+    numericCode: '600'
+  },
+  {
+    name: 'Pérou',
+    alpha2Code: 'PE',
+    alpha3Code: 'PER',
+    numericCode: '604'
+  },
+  {
+    name: 'Philippines',
+    alpha2Code: 'PH',
+    alpha3Code: 'PHL',
+    numericCode: '608'
+  },
+  {
+    name: 'Pologne',
+    alpha2Code: 'PL',
+    alpha3Code: 'POL',
+    numericCode: '616'
+  },
+  {
+    name: 'Portugal',
+    alpha2Code: 'PT',
+    alpha3Code: 'PRT',
+    numericCode: '620'
+  },
+  {
+    name: 'Puerto Rico',
+    alpha2Code: 'PR',
+    alpha3Code: 'PRI',
+    numericCode: '630'
+  },
+  {
+    name: 'Qatar',
+    alpha2Code: 'QA',
+    alpha3Code: 'QAT',
+    numericCode: '634'
+  },
+  {
+    name: 'République de Macédoine du Nord',
+    alpha2Code: 'MK',
+    alpha3Code: 'MKD',
+    numericCode: '807'
+  },
+  {
+    name: 'Roumanie',
+    alpha2Code: 'RO',
+    alpha3Code: 'ROU',
+    numericCode: '642'
+  },
+  {
+    name: 'Fédération de Russie (la)',
+    alpha2Code: 'RU',
+    alpha3Code: 'RUS',
+    numericCode: '643'
+  },
+  {
+    name: 'Rwanda',
+    alpha2Code: 'RW',
+    alpha3Code: 'RWA',
+    numericCode: '646'
+  },
+  {
+    name: 'Saint Kitts et Nevis',
+    alpha2Code: 'KN',
+    alpha3Code: 'KNA',
+    numericCode: '659'
+  },
+  {
+    name: 'Sainte Lucie',
+    alpha2Code: 'LC',
+    alpha3Code: 'LCA',
+    numericCode: '662'
+  },
+  {
+    name: 'Saint-Vincent-et-les Grenadines',
+    alpha2Code: 'VC',
+    alpha3Code: 'VCT',
+    numericCode: '670'
+  },
+  {
+    name: 'Samoa',
+    alpha2Code: 'WS',
+    alpha3Code: 'WSM',
+    numericCode: '882'
+  },
+  {
+    name: 'Saint-Marin',
+    alpha2Code: 'SM',
+    alpha3Code: 'SMR',
+    numericCode: '674'
+  },
+  {
+    name: 'Sao Tomé-et-Principe',
+    alpha2Code: 'ST',
+    alpha3Code: 'STP',
+    numericCode: '678'
+  },
+  {
+    name: 'Arabie saoudite',
+    alpha2Code: 'SA',
+    alpha3Code: 'SAU',
+    numericCode: '682'
+  },
+  {
+    name: 'Sénégal',
+    alpha2Code: 'SN',
+    alpha3Code: 'SEN',
+    numericCode: '686'
+  },
+  {
+    name: 'Serbie',
+    alpha2Code: 'RS',
+    alpha3Code: 'SRB',
+    numericCode: '688'
+  },
+  {
+    name: 'Seychelles',
+    alpha2Code: 'SC',
+    alpha3Code: 'SYC',
+    numericCode: '690'
+  },
+  {
+    name: 'Sierra Leone',
+    alpha2Code: 'SL',
+    alpha3Code: 'SLE',
+    numericCode: '694'
+  },
+  {
     name: 'Singapour',
     alpha2Code: 'SG',
     alpha3Code: 'SGP',
     numericCode: '702'
   },
-    {
-      name: 'Slovaquie',
-      alpha2Code: 'SK',
-      alpha3Code: 'SVK',
-      numericCode: '703'
-    },
-    {
-      name: 'Slovénie',
-      alpha2Code: 'SI',
-      alpha3Code: 'SVN',
-      numericCode: '705'
-    },
-    {
-      name: 'Îles Salomon',
-      alpha2Code: 'SB',
-      alpha3Code: 'SLB',
-      numericCode: '090'
-    },
-    {
-      name: 'Somalie',
-      alpha2Code: 'SO',
-      alpha3Code: 'SOM',
-      numericCode: '706'
-    },
-    {
-      name: 'Afrique du Sud',
-      alpha2Code: 'ZA',
-      alpha3Code: 'ZAF',
-      numericCode: '710'
-    },
-    {
-      name: 'Soudan du Sud',
-      alpha2Code: 'SS',
-      alpha3Code: 'SSD',
-      numericCode: '728'
-    },
-    {
-      name: 'Espagne',
-      alpha2Code: 'ES',
-      alpha3Code: 'ESP',
-      numericCode: '724'
-    },
-    {
-      name: 'Sri Lanka',
-      alpha2Code: 'LK',
-      alpha3Code: 'LKA',
-      numericCode: '144'
-    },
-    {
-      name: 'Soudan',
-      alpha2Code: 'SD',
-      alpha3Code: 'SDN',
-      numericCode: '729'
-    },
-    {
-      name: 'Suriname',
-      alpha2Code: 'SR',
-      alpha3Code: 'SUR',
-      numericCode: '740'
-    },
-    {
-      name: 'Suède',
-      alpha2Code: 'SE',
-      alpha3Code: 'SWE',
-      numericCode: '752'
-    },
-    {
-      name: 'Suisse',
-      alpha2Code: 'CH',
-      alpha3Code: 'CHE',
-      numericCode: '756'
-    },
-    {
-      name: 'République arabe syrienne',
-      alpha2Code: 'SY',
-      alpha3Code: 'SYR',
-      numericCode: '760'
-    },
-    {
-      name: 'Taiwan',
-      alpha2Code: 'TW',
-      alpha3Code: 'TWN',
-      numericCode: '158'
-    },
-    {
-      name: 'Tadjikistan',
-      alpha2Code: 'TJ',
-      alpha3Code: 'TJK',
-      numericCode: '762'
-    },
-    {
-      name: 'Tanzanie',
-      alpha2Code: 'TZ',
-      alpha3Code: 'TZA',
-      numericCode: '834'
-    },
-    {
-      name: 'Thaïlande',
-      alpha2Code: 'TH',
-      alpha3Code: 'THA',
-      numericCode: '764'
-    },
-    {
-      name: 'Timor-Leste',
-      alpha2Code: 'TL',
-      alpha3Code: 'TLS',
-      numericCode: '626'
-    },
-    {
-      name: 'Togo',
-      alpha2Code: 'TG',
-      alpha3Code: 'TGO',
-      numericCode: '768'
-    },
-    {
-      name: 'Tonga',
-      alpha2Code: 'TO',
-      alpha3Code: 'TON',
-      numericCode: '776'
-    },
-    {
-      name: 'Trinité-et-Tobago',
-      alpha2Code: 'TT',
-      alpha3Code: 'TTO',
-      numericCode: '780'
-    },
-    {
-      name: 'Tunisie',
-      alpha2Code: 'TN',
-      alpha3Code: 'TUN',
-      numericCode: '788'
-    },
-    {
-      name: 'Turquie',
-      alpha2Code: 'TR',
-      alpha3Code: 'TUR',
-      numericCode: '792'
-    },
-    {
-      name: 'Turkménistan',
-      alpha2Code: 'TM',
-      alpha3Code: 'TKM',
-      numericCode: '795'
-    },
-    {
-      name: 'Tuvalu',
-      alpha2Code: 'TV',
-      alpha3Code: 'TUV',
-      numericCode: '798'
-    },
-    {
-      name: 'Ouganda',
-      alpha2Code: 'UG',
-      alpha3Code: 'UGA',
-      numericCode: '800'
-    },
-    {
-      name: 'Ukraine',
-      alpha2Code: 'UA',
-      alpha3Code: 'UKR',
-      numericCode: '804'
-    },
-    {
-      name: 'Emirats Arabes Unis',
-      alpha2Code: 'AE',
-      alpha3Code: 'ARE',
-      numericCode: '784'
-    },
-    {
-      name: 'Royaume-Uni',
-      alpha2Code: 'GB',
-      alpha3Code: 'GBR',
-      numericCode: '826'
-    },
-    {
-      name: 'États-Unis d\'Amérique',
-      alpha2Code: 'US',
-      alpha3Code: 'USA',
-      numericCode: '840'
-    },
-    {
-      name: 'Uruguay',
-      alpha2Code: 'UY',
-      alpha3Code: 'URY',
-      numericCode: '858'
-    },
-    {
-      name: 'Ouzbékistan',
-      alpha2Code: 'UZ',
-      alpha3Code: 'UZB',
-      numericCode: '860'
-    },
-    {
-      name: 'Vanuatu',
-      alpha2Code: 'VU',
-      alpha3Code: 'VUT',
-      numericCode: '548'
-    },
-    {
-      name: 'Venezuela',
-      alpha2Code: 'VE',
-      alpha3Code: 'VEN',
-      numericCode: '862'
-    },
-    {
-      name: 'Vietnam',
-      alpha2Code: 'VN',
-      alpha3Code: 'VNM',
-      numericCode: '704'
-    },
-    {
-      name: 'Yémen',
-      alpha2Code: 'OUI',
-      alpha3Code: 'YEM',
-      numericCode: '887'
-    },
-    {
-      name: 'Zambie',
-      alpha2Code: 'ZM',
-      alpha3Code: 'ZMB',
-      numericCode: '894'
-    },
-    {
-      name: 'Zimbabwe',
-      alpha2Code: 'ZW',
-      alpha3Code: 'ZWE',
-      numericCode: '716'
-    }
-  ]
-;
+  {
+    name: 'Slovaquie',
+    alpha2Code: 'SK',
+    alpha3Code: 'SVK',
+    numericCode: '703'
+  },
+  {
+    name: 'Slovénie',
+    alpha2Code: 'SI',
+    alpha3Code: 'SVN',
+    numericCode: '705'
+  },
+  {
+    name: 'Îles Salomon',
+    alpha2Code: 'SB',
+    alpha3Code: 'SLB',
+    numericCode: '090'
+  },
+  {
+    name: 'Somalie',
+    alpha2Code: 'SO',
+    alpha3Code: 'SOM',
+    numericCode: '706'
+  },
+  {
+    name: 'Afrique du Sud',
+    alpha2Code: 'ZA',
+    alpha3Code: 'ZAF',
+    numericCode: '710'
+  },
+  {
+    name: 'Soudan du Sud',
+    alpha2Code: 'SS',
+    alpha3Code: 'SSD',
+    numericCode: '728'
+  },
+  {
+    name: 'Espagne',
+    alpha2Code: 'ES',
+    alpha3Code: 'ESP',
+    numericCode: '724'
+  },
+  {
+    name: 'Sri Lanka',
+    alpha2Code: 'LK',
+    alpha3Code: 'LKA',
+    numericCode: '144'
+  },
+  {
+    name: 'Soudan',
+    alpha2Code: 'SD',
+    alpha3Code: 'SDN',
+    numericCode: '729'
+  },
+  {
+    name: 'Suriname',
+    alpha2Code: 'SR',
+    alpha3Code: 'SUR',
+    numericCode: '740'
+  },
+  {
+    name: 'Suède',
+    alpha2Code: 'SE',
+    alpha3Code: 'SWE',
+    numericCode: '752'
+  },
+  {
+    name: 'Suisse',
+    alpha2Code: 'CH',
+    alpha3Code: 'CHE',
+    numericCode: '756'
+  },
+  {
+    name: 'République arabe syrienne',
+    alpha2Code: 'SY',
+    alpha3Code: 'SYR',
+    numericCode: '760'
+  },
+  {
+    name: 'Taiwan',
+    alpha2Code: 'TW',
+    alpha3Code: 'TWN',
+    numericCode: '158'
+  },
+  {
+    name: 'Tadjikistan',
+    alpha2Code: 'TJ',
+    alpha3Code: 'TJK',
+    numericCode: '762'
+  },
+  {
+    name: 'Tanzanie',
+    alpha2Code: 'TZ',
+    alpha3Code: 'TZA',
+    numericCode: '834'
+  },
+  {
+    name: 'Thaïlande',
+    alpha2Code: 'TH',
+    alpha3Code: 'THA',
+    numericCode: '764'
+  },
+  {
+    name: 'Timor-Leste',
+    alpha2Code: 'TL',
+    alpha3Code: 'TLS',
+    numericCode: '626'
+  },
+  {
+    name: 'Togo',
+    alpha2Code: 'TG',
+    alpha3Code: 'TGO',
+    numericCode: '768'
+  },
+  {
+    name: 'Tonga',
+    alpha2Code: 'TO',
+    alpha3Code: 'TON',
+    numericCode: '776'
+  },
+  {
+    name: 'Trinité-et-Tobago',
+    alpha2Code: 'TT',
+    alpha3Code: 'TTO',
+    numericCode: '780'
+  },
+  {
+    name: 'Tunisie',
+    alpha2Code: 'TN',
+    alpha3Code: 'TUN',
+    numericCode: '788'
+  },
+  {
+    name: 'Turquie',
+    alpha2Code: 'TR',
+    alpha3Code: 'TUR',
+    numericCode: '792'
+  },
+  {
+    name: 'Turkménistan',
+    alpha2Code: 'TM',
+    alpha3Code: 'TKM',
+    numericCode: '795'
+  },
+  {
+    name: 'Tuvalu',
+    alpha2Code: 'TV',
+    alpha3Code: 'TUV',
+    numericCode: '798'
+  },
+  {
+    name: 'Ouganda',
+    alpha2Code: 'UG',
+    alpha3Code: 'UGA',
+    numericCode: '800'
+  },
+  {
+    name: 'Ukraine',
+    alpha2Code: 'UA',
+    alpha3Code: 'UKR',
+    numericCode: '804'
+  },
+  {
+    name: 'Emirats Arabes Unis',
+    alpha2Code: 'AE',
+    alpha3Code: 'ARE',
+    numericCode: '784'
+  },
+  {
+    name: 'Royaume-Uni',
+    alpha2Code: 'GB',
+    alpha3Code: 'GBR',
+    numericCode: '826'
+  },
+  {
+    name: "États-Unis d'Amérique",
+    alpha2Code: 'US',
+    alpha3Code: 'USA',
+    numericCode: '840'
+  },
+  {
+    name: 'Uruguay',
+    alpha2Code: 'UY',
+    alpha3Code: 'URY',
+    numericCode: '858'
+  },
+  {
+    name: 'Ouzbékistan',
+    alpha2Code: 'UZ',
+    alpha3Code: 'UZB',
+    numericCode: '860'
+  },
+  {
+    name: 'Vanuatu',
+    alpha2Code: 'VU',
+    alpha3Code: 'VUT',
+    numericCode: '548'
+  },
+  {
+    name: 'Venezuela',
+    alpha2Code: 'VE',
+    alpha3Code: 'VEN',
+    numericCode: '862'
+  },
+  {
+    name: 'Vietnam',
+    alpha2Code: 'VN',
+    alpha3Code: 'VNM',
+    numericCode: '704'
+  },
+  {
+    name: 'Yémen',
+    alpha2Code: 'YE',
+    alpha3Code: 'YEM',
+    numericCode: '887'
+  },
+  {
+    name: 'Zambie',
+    alpha2Code: 'ZM',
+    alpha3Code: 'ZMB',
+    numericCode: '894'
+  },
+  {
+    name: 'Zimbabwe',
+    alpha2Code: 'ZW',
+    alpha3Code: 'ZWE',
+    numericCode: '716'
+  }
+];

--- a/projects/angular-material-extensions/select-country/src/lib/i18n/it.ts
+++ b/projects/angular-material-extensions/select-country/src/lib/i18n/it.ts
@@ -1,1218 +1,1222 @@
-import {Country} from '../mat-select-country.component';
+import { Country } from '../mat-select-country.component';
 
-export const COUNTRIES_DB_IT: Country[] =
-  [{
+export const COUNTRIES_DB_IT: Country[] = [
+  {
     name: 'Afghanistan',
     alpha2Code: 'AF',
     alpha3Code: 'AFG',
     numericCode: '004'
   },
-    {
-      name: 'Albania',
-      alpha2Code: 'AL',
-      alpha3Code: 'ALB',
-      numericCode: '008'
-    },
-    {
-      name: 'Algeria',
-      alpha2Code: 'DZ',
-      alpha3Code: 'DZA',
-      numericCode: '012'
-    },
-    {
-      name: 'Samoa americane',
-      alpha2Code: 'AS',
-      alpha3Code: 'ASM',
-      numericCode: '016'
-    },
-    {
-      name: 'Andorra',
-      alpha2Code: 'AD',
-      alpha3Code: 'AND',
-      numericCode: '020'
-    },
-    {
-      name: 'Angola',
-      alpha2Code: 'AO',
-      alpha3Code: 'AGO',
-      numericCode: '024'
-    },
-    {
-      name: 'Antigua e Barbuda',
-      alpha2Code: 'AG',
-      alpha3Code: 'ATG',
-      numericCode: '028'
-    },
-    {
-      name: 'Argentina',
-      alpha2Code: 'AR',
-      alpha3Code: 'ARG',
-      numericCode: '032'
-    },
-    {
-      name: 'Armenia',
-      alpha2Code: 'AM',
-      alpha3Code: 'ARM',
-      numericCode: '051'
-    },
-    {
-      name: 'Australia',
-      alpha2Code: 'AU',
-      alpha3Code: 'AUS',
-      numericCode: '036'
-    },
-    {
-      name: 'Austria',
-      alpha2Code: 'AT',
-      alpha3Code: 'AUT',
-      numericCode: '040'
-    },
-    {
-      name: 'Azerbaijan',
-      alpha2Code: 'AZ',
-      alpha3Code: 'AZE',
-      numericCode: '031'
-    },
-    {
-      name: 'Bahamas',
-      alpha2Code: 'BS',
-      alpha3Code: 'BHS',
-      numericCode: '044'
-    },
-    {
-      name: 'Bahrain',
-      alpha2Code: 'BH',
-      alpha3Code: 'BHR',
-      numericCode: '048'
-    },
-    {
-      name: 'Bangladesh',
-      alpha2Code: 'BD',
-      alpha3Code: 'BGD',
-      numericCode: '050'
-    },
-    {
-      name: 'Barbados',
-      alpha2Code: 'BB',
-      alpha3Code: 'BRB',
-      numericCode: '052'
-    },
-    {
-      name: 'Bielorussia',
-      alpha2Code: 'BY',
-      alpha3Code: 'BLR',
-      numericCode: '112'
-    },
-    {
-      name: 'Belgio',
-      alpha2Code: 'BE',
-      alpha3Code: 'BEL',
-      numericCode: '056'
-    },
-    {
-      name: 'Belize',
-      alpha2Code: 'BZ',
-      alpha3Code: 'BLZ',
-      numericCode: '084'
-    },
-    {
-      name: 'Benin',
-      alpha2Code: 'BJ',
-      alpha3Code: 'BEN',
-      numericCode: '204'
-    },
-    {
-      name: 'Bermuda',
-      alpha2Code: 'BM',
-      alpha3Code: 'BMU',
-      numericCode: '060'
-    },
-    {
-      name: 'Bhutan',
-      alpha2Code: 'BT',
-      alpha3Code: 'BTN',
-      numericCode: '064'
-    },
-    {
-      name: 'Bolivia',
-      alpha2Code: 'BO',
-      alpha3Code: 'BOL',
-      numericCode: '068'
-    },
-    {
-      name: 'Bonaire, Sint Eustatius e Saba',
-      alpha2Code: 'BQ',
-      alpha3Code: 'BES',
-      numericCode: '535'
-    },
-    {
-      name: 'Bosnia ed Erzegovina',
-      alpha2Code: 'BA',
-      alpha3Code: 'BIH',
-      numericCode: '070'
-    },
-    {
-      name: 'Botswana',
-      alpha2Code: 'BW',
-      alpha3Code: 'BWA',
-      numericCode: '072'
-    },
-    {
-      name: 'Isola Bouvet',
-      alpha2Code: 'BV',
-      alpha3Code: 'BVT',
-      numericCode: '074'
-    }, {
+  {
+    name: 'Albania',
+    alpha2Code: 'AL',
+    alpha3Code: 'ALB',
+    numericCode: '008'
+  },
+  {
+    name: 'Algeria',
+    alpha2Code: 'DZ',
+    alpha3Code: 'DZA',
+    numericCode: '012'
+  },
+  {
+    name: 'Samoa americane',
+    alpha2Code: 'AS',
+    alpha3Code: 'ASM',
+    numericCode: '016'
+  },
+  {
+    name: 'Andorra',
+    alpha2Code: 'AD',
+    alpha3Code: 'AND',
+    numericCode: '020'
+  },
+  {
+    name: 'Angola',
+    alpha2Code: 'AO',
+    alpha3Code: 'AGO',
+    numericCode: '024'
+  },
+  {
+    name: 'Antigua e Barbuda',
+    alpha2Code: 'AG',
+    alpha3Code: 'ATG',
+    numericCode: '028'
+  },
+  {
+    name: 'Argentina',
+    alpha2Code: 'AR',
+    alpha3Code: 'ARG',
+    numericCode: '032'
+  },
+  {
+    name: 'Armenia',
+    alpha2Code: 'AM',
+    alpha3Code: 'ARM',
+    numericCode: '051'
+  },
+  {
+    name: 'Australia',
+    alpha2Code: 'AU',
+    alpha3Code: 'AUS',
+    numericCode: '036'
+  },
+  {
+    name: 'Austria',
+    alpha2Code: 'AT',
+    alpha3Code: 'AUT',
+    numericCode: '040'
+  },
+  {
+    name: 'Azerbaijan',
+    alpha2Code: 'AZ',
+    alpha3Code: 'AZE',
+    numericCode: '031'
+  },
+  {
+    name: 'Bahamas',
+    alpha2Code: 'BS',
+    alpha3Code: 'BHS',
+    numericCode: '044'
+  },
+  {
+    name: 'Bahrain',
+    alpha2Code: 'BH',
+    alpha3Code: 'BHR',
+    numericCode: '048'
+  },
+  {
+    name: 'Bangladesh',
+    alpha2Code: 'BD',
+    alpha3Code: 'BGD',
+    numericCode: '050'
+  },
+  {
+    name: 'Barbados',
+    alpha2Code: 'BB',
+    alpha3Code: 'BRB',
+    numericCode: '052'
+  },
+  {
+    name: 'Bielorussia',
+    alpha2Code: 'BY',
+    alpha3Code: 'BLR',
+    numericCode: '112'
+  },
+  {
+    name: 'Belgio',
+    alpha2Code: 'BE',
+    alpha3Code: 'BEL',
+    numericCode: '056'
+  },
+  {
+    name: 'Belize',
+    alpha2Code: 'BZ',
+    alpha3Code: 'BLZ',
+    numericCode: '084'
+  },
+  {
+    name: 'Benin',
+    alpha2Code: 'BJ',
+    alpha3Code: 'BEN',
+    numericCode: '204'
+  },
+  {
+    name: 'Bermuda',
+    alpha2Code: 'BM',
+    alpha3Code: 'BMU',
+    numericCode: '060'
+  },
+  {
+    name: 'Bhutan',
+    alpha2Code: 'BT',
+    alpha3Code: 'BTN',
+    numericCode: '064'
+  },
+  {
+    name: 'Bolivia',
+    alpha2Code: 'BO',
+    alpha3Code: 'BOL',
+    numericCode: '068'
+  },
+  {
+    name: 'Bonaire, Sint Eustatius e Saba',
+    alpha2Code: 'BQ',
+    alpha3Code: 'BES',
+    numericCode: '535'
+  },
+  {
+    name: 'Bosnia ed Erzegovina',
+    alpha2Code: 'BA',
+    alpha3Code: 'BIH',
+    numericCode: '070'
+  },
+  {
+    name: 'Botswana',
+    alpha2Code: 'BW',
+    alpha3Code: 'BWA',
+    numericCode: '072'
+  },
+  {
+    name: 'Isola Bouvet',
+    alpha2Code: 'BV',
+    alpha3Code: 'BVT',
+    numericCode: '074'
+  },
+  {
     name: 'Brasile',
     alpha2Code: 'BR',
     alpha3Code: 'BRA',
     numericCode: '076'
   },
-    {
-      name: 'Brunei',
-      alpha2Code: 'BN',
-      alpha3Code: 'BRN',
-      numericCode: '096'
-    },
-    {
-      name: 'Bulgaria',
-      alpha2Code: 'BG',
-      alpha3Code: 'BGR',
-      numericCode: '100'
-    },
-    {
-      name: 'Burkina Faso',
-      alpha2Code: 'BF',
-      alpha3Code: 'BFA',
-      numericCode: '854'
-    },
-    {
-      name: 'Burundi',
-      alpha2Code: 'BI',
-      alpha3Code: 'BDI',
-      numericCode: '108'
-    },
-    {
-      name: 'Cabo Verde',
-      alpha2Code: 'CV',
-      alpha3Code: 'CPV',
-      numericCode: '132'
-    },
-    {
-      name: 'Cambogia',
-      alpha2Code: 'KH',
-      alpha3Code: 'KHM',
-      numericCode: '116'
-    },
-    {
-      name: 'Camerun',
-      alpha2Code: 'CM',
-      alpha3Code: 'CMR',
-      numericCode: '120'
-    },
-    {
-      name: 'Canada',
-      alpha2Code: 'CA',
-      alpha3Code: 'CAN',
-      numericCode: '124'
-    },
-    {
-      name: 'Repubblica Centrafricana',
-      alpha2Code: 'CF',
-      alpha3Code: 'CAF',
-      numericCode: '140'
-    },
-    {
-      name: 'Chad',
-      alpha2Code: 'TD',
-      alpha3Code: 'TCD',
-      numericCode: '148'
-    },
-    {
-      name: 'Cile',
-      alpha2Code: 'CL',
-      alpha3Code: 'CHL',
-      numericCode: '152'
-    },
-    {
-      name: 'Cina',
-      alpha2Code: 'CN',
-      alpha3Code: 'CHN',
-      numericCode: '156'
-    },
-    {
-      name: 'Colombia',
-      alpha2Code: 'CO',
-      alpha3Code: 'COL',
-      numericCode: '170'
-    },
-    {
-      name: 'Congo (Repubblica Democratica del)',
-      alpha2Code: 'CD',
-      alpha3Code: 'COD',
-      numericCode: '180'
-    },
-    {
-      name: 'Congo (Repubblica del)',
-      alpha2Code: 'CG',
-      alpha3Code: 'COG',
-      numericCode: '178'
-    },
-    {
-      name: 'Costa Rica',
-      alpha2Code: 'CR',
-      alpha3Code: 'CRI',
-      numericCode: '188'
-    },
-    {
-      name: 'Croazia',
-      alpha2Code: 'HR',
-      alpha3Code: 'HRV',
-      numericCode: '191'
-    },
-    {
-      name: 'Cuba',
-      alpha2Code: 'CU',
-      alpha3Code: 'CUB',
-      numericCode: '192'
-    },
-    {
-      name: 'Cipro',
-      alpha2Code: 'CY',
-      alpha3Code: 'CYP',
-      numericCode: '196'
-    },
-    {
-      name: 'Czechia',
-      alpha2Code: 'CZ',
-      alpha3Code: 'CZE',
-      numericCode: '203'
-    },
-    {
-      name: 'Côte d \' Ivoire ',
-      alpha2Code: 'CI',
-      alpha3Code: 'CIV',
-      numericCode: '384'
-    },
-    {
-      name: 'Danimarca',
-      alpha2Code: 'DK',
-      alpha3Code: 'DNK',
-      numericCode: '208'
-    },
-    {
-      name: 'Gibuti',
-      alpha2Code: 'DJ',
-      alpha3Code: 'DJI',
-      numericCode: '262'
-    },
-    {
-      name: 'Dominica',
-      alpha2Code: 'DM',
-      alpha3Code: 'DMA',
-      numericCode: '212'
-    },
-    {
-      name: 'Repubblica Dominicana',
-      alpha2Code: 'DO',
-      alpha3Code: 'DOM',
-      numericCode: '214'
-    },
-    {
-      name: 'Ecuador',
-      alpha2Code: 'EC',
-      alpha3Code: 'ECU',
-      numericCode: '218'
-    },
-    {
-      name: 'Egitto',
-      alpha2Code: 'EG',
-      alpha3Code: 'EGY',
-      numericCode: '818'
-    },
-    {
-      name: 'El Salvador',
-      alpha2Code: 'SV',
-      alpha3Code: 'SLV',
-      numericCode: '222'
-    },
-    {
-      name: 'Guinea Equatoriale',
-      alpha2Code: 'GQ',
-      alpha3Code: 'GNQ',
-      numericCode: '226'
-    },
-    {
-      name: 'Eritrea',
-      alpha2Code: 'ER',
-      alpha3Code: 'ERI',
-      numericCode: '232'
-    },
-    {
-      name: 'Estonia',
-      alpha2Code: 'EE',
-      alpha3Code: 'EST',
-      numericCode: '233'
-    },
-    {
-      name: 'Eswatini',
-      alpha2Code: 'SZ',
-      alpha3Code: 'SWZ',
-      numericCode: '748'
-    },
-    {
-      name: 'Etiopia',
-      alpha2Code: 'ET',
-      alpha3Code: 'ETH',
-      numericCode: '231'
-    },
-    {
-      name: 'Fiji',
-      alpha2Code: 'FJ',
-      alpha3Code: 'FJI',
-      numericCode: '242'
-    },
-    {
-      name: 'Finlandia',
-      alpha2Code: 'FI',
-      alpha3Code: 'FIN',
-      numericCode: '246'
-    },
-    {
-      name: 'Francia',
-      alpha2Code: 'FR',
-      alpha3Code: 'FRA',
-      numericCode: '250'
-    },
-    {
-      name: 'Gabon',
-      alpha2Code: 'GA',
-      alpha3Code: 'GAB',
-      numericCode: '266'
-    },
-    {
-      name: 'Gambia',
-      alpha2Code: 'GM',
-      alpha3Code: 'GMB',
-      numericCode: '270'
-    },
-    {
-      name: 'Georgia',
-      alpha2Code: 'GE',
-      alpha3Code: 'GEO',
-      numericCode: '268'
-    },
-    {
-      name: 'Germania',
-      alpha2Code: 'DE',
-      alpha3Code: 'DEU',
-      numericCode: '276'
-    },
-    {
-      name: 'Ghana',
-      alpha2Code: 'GH',
-      alpha3Code: 'GHA',
-      numericCode: '288'
-    }, {
+  {
+    name: 'Brunei',
+    alpha2Code: 'BN',
+    alpha3Code: 'BRN',
+    numericCode: '096'
+  },
+  {
+    name: 'Bulgaria',
+    alpha2Code: 'BG',
+    alpha3Code: 'BGR',
+    numericCode: '100'
+  },
+  {
+    name: 'Burkina Faso',
+    alpha2Code: 'BF',
+    alpha3Code: 'BFA',
+    numericCode: '854'
+  },
+  {
+    name: 'Burundi',
+    alpha2Code: 'BI',
+    alpha3Code: 'BDI',
+    numericCode: '108'
+  },
+  {
+    name: 'Cabo Verde',
+    alpha2Code: 'CV',
+    alpha3Code: 'CPV',
+    numericCode: '132'
+  },
+  {
+    name: 'Cambogia',
+    alpha2Code: 'KH',
+    alpha3Code: 'KHM',
+    numericCode: '116'
+  },
+  {
+    name: 'Camerun',
+    alpha2Code: 'CM',
+    alpha3Code: 'CMR',
+    numericCode: '120'
+  },
+  {
+    name: 'Canada',
+    alpha2Code: 'CA',
+    alpha3Code: 'CAN',
+    numericCode: '124'
+  },
+  {
+    name: 'Repubblica Centrafricana',
+    alpha2Code: 'CF',
+    alpha3Code: 'CAF',
+    numericCode: '140'
+  },
+  {
+    name: 'Chad',
+    alpha2Code: 'TD',
+    alpha3Code: 'TCD',
+    numericCode: '148'
+  },
+  {
+    name: 'Cile',
+    alpha2Code: 'CL',
+    alpha3Code: 'CHL',
+    numericCode: '152'
+  },
+  {
+    name: 'Cina',
+    alpha2Code: 'CN',
+    alpha3Code: 'CHN',
+    numericCode: '156'
+  },
+  {
+    name: 'Colombia',
+    alpha2Code: 'CO',
+    alpha3Code: 'COL',
+    numericCode: '170'
+  },
+  {
+    name: 'Congo (Repubblica Democratica del)',
+    alpha2Code: 'CD',
+    alpha3Code: 'COD',
+    numericCode: '180'
+  },
+  {
+    name: 'Congo (Repubblica del)',
+    alpha2Code: 'CG',
+    alpha3Code: 'COG',
+    numericCode: '178'
+  },
+  {
+    name: 'Costa Rica',
+    alpha2Code: 'CR',
+    alpha3Code: 'CRI',
+    numericCode: '188'
+  },
+  {
+    name: 'Croazia',
+    alpha2Code: 'HR',
+    alpha3Code: 'HRV',
+    numericCode: '191'
+  },
+  {
+    name: 'Cuba',
+    alpha2Code: 'CU',
+    alpha3Code: 'CUB',
+    numericCode: '192'
+  },
+  {
+    name: 'Cipro',
+    alpha2Code: 'CY',
+    alpha3Code: 'CYP',
+    numericCode: '196'
+  },
+  {
+    name: 'Czechia',
+    alpha2Code: 'CZ',
+    alpha3Code: 'CZE',
+    numericCode: '203'
+  },
+  {
+    name: "Côte d ' Ivoire ",
+    alpha2Code: 'CI',
+    alpha3Code: 'CIV',
+    numericCode: '384'
+  },
+  {
+    name: 'Danimarca',
+    alpha2Code: 'DK',
+    alpha3Code: 'DNK',
+    numericCode: '208'
+  },
+  {
+    name: 'Gibuti',
+    alpha2Code: 'DJ',
+    alpha3Code: 'DJI',
+    numericCode: '262'
+  },
+  {
+    name: 'Dominica',
+    alpha2Code: 'DM',
+    alpha3Code: 'DMA',
+    numericCode: '212'
+  },
+  {
+    name: 'Repubblica Dominicana',
+    alpha2Code: 'DO',
+    alpha3Code: 'DOM',
+    numericCode: '214'
+  },
+  {
+    name: 'Ecuador',
+    alpha2Code: 'EC',
+    alpha3Code: 'ECU',
+    numericCode: '218'
+  },
+  {
+    name: 'Egitto',
+    alpha2Code: 'EG',
+    alpha3Code: 'EGY',
+    numericCode: '818'
+  },
+  {
+    name: 'El Salvador',
+    alpha2Code: 'SV',
+    alpha3Code: 'SLV',
+    numericCode: '222'
+  },
+  {
+    name: 'Guinea Equatoriale',
+    alpha2Code: 'GQ',
+    alpha3Code: 'GNQ',
+    numericCode: '226'
+  },
+  {
+    name: 'Eritrea',
+    alpha2Code: 'ER',
+    alpha3Code: 'ERI',
+    numericCode: '232'
+  },
+  {
+    name: 'Estonia',
+    alpha2Code: 'EE',
+    alpha3Code: 'EST',
+    numericCode: '233'
+  },
+  {
+    name: 'Eswatini',
+    alpha2Code: 'SZ',
+    alpha3Code: 'SWZ',
+    numericCode: '748'
+  },
+  {
+    name: 'Etiopia',
+    alpha2Code: 'ET',
+    alpha3Code: 'ETH',
+    numericCode: '231'
+  },
+  {
+    name: 'Fiji',
+    alpha2Code: 'FJ',
+    alpha3Code: 'FJI',
+    numericCode: '242'
+  },
+  {
+    name: 'Finlandia',
+    alpha2Code: 'FI',
+    alpha3Code: 'FIN',
+    numericCode: '246'
+  },
+  {
+    name: 'Francia',
+    alpha2Code: 'FR',
+    alpha3Code: 'FRA',
+    numericCode: '250'
+  },
+  {
+    name: 'Gabon',
+    alpha2Code: 'GA',
+    alpha3Code: 'GAB',
+    numericCode: '266'
+  },
+  {
+    name: 'Gambia',
+    alpha2Code: 'GM',
+    alpha3Code: 'GMB',
+    numericCode: '270'
+  },
+  {
+    name: 'Georgia',
+    alpha2Code: 'GE',
+    alpha3Code: 'GEO',
+    numericCode: '268'
+  },
+  {
+    name: 'Germania',
+    alpha2Code: 'DE',
+    alpha3Code: 'DEU',
+    numericCode: '276'
+  },
+  {
+    name: 'Ghana',
+    alpha2Code: 'GH',
+    alpha3Code: 'GHA',
+    numericCode: '288'
+  },
+  {
     name: 'Grecia',
     alpha2Code: 'GR',
     alpha3Code: 'GRC',
     numericCode: '300'
   },
-    {
-      name: 'Groenlandia',
-      alpha2Code: 'GL',
-      alpha3Code: 'GRL',
-      numericCode: '304'
-    },
-    {
-      name: 'Guadalupa',
-      alpha2Code: 'GP',
-      alpha3Code: 'GLP',
-      numericCode: '312'
-    },
-    {
-      name: 'Grenada',
-      alpha2Code: 'GD',
-      alpha3Code: 'GRD',
-      numericCode: '308'
-    },
-    {
-      name: 'Guatemala',
-      alpha2Code: 'GT',
-      alpha3Code: 'GTM',
-      numericCode: '320'
-    },
-    {
-      name: 'Guinea',
-      alpha2Code: 'GN',
-      alpha3Code: 'GIN',
-      numericCode: '324'
-    },
-    {
-      name: 'Guinea-Bissau',
-      alpha2Code: 'GW',
-      alpha3Code: 'GNB',
-      numericCode: '624'
-    },
-    {
-      name: 'Guyana',
-      alpha2Code: 'GY',
-      alpha3Code: 'GUY',
-      numericCode: '328'
-    },
-    {
-      name: 'Haiti',
-      alpha2Code: 'HT',
-      alpha3Code: 'HTI',
-      numericCode: '332'
-    },
-    {
-      name: 'Honduras',
-      alpha2Code: 'HN',
-      alpha3Code: 'HND',
-      numericCode: '340'
-    },
-    {
-      name: 'Hong Kong',
-      alpha2Code: 'HK',
-      alpha3Code: 'HKG',
-      numericCode: '344'
-    },
-    {
-      name: 'Ungheria',
-      alpha2Code: 'HU',
-      alpha3Code: 'HUN',
-      numericCode: '348'
-    },
-    {
-      name: 'Islanda',
-      alpha2Code: 'IS',
-      alpha3Code: 'ISL',
-      numericCode: '352'
-    },
-    {
-      name: 'India',
-      alpha2Code: 'IN',
-      alpha3Code: 'IND',
-      numericCode: '356'
-    },
-    {
-      name: 'Indonesia',
-      alpha2Code: 'ID',
-      alpha3Code: 'IDN',
-      numericCode: '360'
-    },
-    {
-      name: 'Iran',
-      alpha2Code: 'IR',
-      alpha3Code: 'IRN',
-      numericCode: '364'
-    },
-    {
-      name: 'Iraq',
-      alpha2Code: 'IQ',
-      alpha3Code: 'IRQ',
-      numericCode: '368'
-    },
-    {
-      name: 'Irlanda',
-      alpha2Code: 'IE',
-      alpha3Code: 'IRL',
-      numericCode: '372'
-    },
-    {
-      name: 'Israel',
-      alpha2Code: 'IL',
-      alpha3Code: 'ISR',
-      numericCode: '376'
-    },
-    {
-      name: 'Italia',
-      alpha2Code: 'IT',
-      alpha3Code: 'ITA',
-      numericCode: '380'
-    },
-    {
-      name: 'Jamaica',
-      alpha2Code: 'JM',
-      alpha3Code: 'JAM',
-      numericCode: '388'
-    },
-    {
-      name: 'Giappone',
-      alpha2Code: 'JP',
-      alpha3Code: 'JPN',
-      numericCode: '392'
-    },
-    {
-      name: 'Jersey',
-      alpha2Code: 'JE',
-      alpha3Code: 'JEY',
-      numericCode: '832'
-    },
-    {
-      name: 'Jordan',
-      alpha2Code: 'JO',
-      alpha3Code: 'JOR',
-      numericCode: '400'
-    },
-    {
-      name: 'Kazakistan',
-      alpha2Code: 'KZ',
-      alpha3Code: 'KAZ',
-      numericCode: '398'
-    },
-    {
-      name: 'Kenya',
-      alpha2Code: 'KE',
-      alpha3Code: 'KEN',
-      numericCode: '404'
-    },
-    {
-      name: 'Kiribati',
-      alpha2Code: 'KI',
-      alpha3Code: 'KIR',
-      numericCode: '296'
-    },
-    {
-      name: 'Corea (Repubblica popolare democratica di)',
-      alpha2Code: 'KP',
-      alpha3Code: 'PRK',
-      numericCode: '408'
-    },
-    {
-      name: 'Corea (Repubblica di) \ t',
-      alpha2Code: 'KR',
-      alpha3Code: 'KOR',
-      numericCode: '410'
-    },
-    {
-      name: 'Kuwait',
-      alpha2Code: 'KW',
-      alpha3Code: 'KWT',
-      numericCode: '414'
-    },
-    {
-      name: 'Kirghizistan',
-      alpha2Code: 'KG',
-      alpha3Code: 'KGZ',
-      numericCode: '417'
-    },
-    {
-      name: 'Laos',
-      alpha2Code: 'LA',
-      alpha3Code: 'LAO',
-      numericCode: '418'
-    },
-    {
-      name: 'Lettonia',
-      alpha2Code: 'LV',
-      alpha3Code: 'LVA',
-      numericCode: '428'
-    },
-    {
-      name: 'Libano',
-      alpha2Code: 'LB',
-      alpha3Code: 'LBN',
-      numericCode: '422'
-    },
-    {
-      name: 'Lesotho',
-      alpha2Code: 'LS',
-      alpha3Code: 'LSO',
-      numericCode: '426'
-    },
-    {
-      name: 'Liberia',
-      alpha2Code: 'LR',
-      alpha3Code: 'LBR',
-      numericCode: '430'
-    },
-    {
-      name: 'Libia',
-      alpha2Code: 'LY',
-      alpha3Code: 'LBY',
-      numericCode: '434'
-    },
-    {
-      name: 'Liechtenstein',
-      alpha2Code: 'LI',
-      alpha3Code: 'LIE',
-      numericCode: '438'
-    },
-    {
-      name: 'Lituania',
-      alpha2Code: 'LT',
-      alpha3Code: 'LTU',
-      numericCode: '440'
-    },
-    {
-      name: 'Lussemburgo',
-      alpha2Code: 'LU',
-      alpha3Code: 'LUX',
-      numericCode: '442'
-    },
-    {
-      name: 'Macao',
-      alpha2Code: 'MO',
-      alpha3Code: 'MAC',
-      numericCode: '446'
-    },
-    {
-      name: 'Madagascar',
-      alpha2Code: 'MG',
-      alpha3Code: 'MDG',
-      numericCode: '450'
-    },
-    {
-      name: 'Malawi',
-      alpha2Code: 'MW',
-      alpha3Code: 'MWI',
-      numericCode: '454'
-    },
-    {
-      name: 'Malaysia',
-      alpha2Code: 'MY',
-      alpha3Code: 'MYS',
-      numericCode: '458'
-    }, {
+  {
+    name: 'Groenlandia',
+    alpha2Code: 'GL',
+    alpha3Code: 'GRL',
+    numericCode: '304'
+  },
+  {
+    name: 'Guadalupa',
+    alpha2Code: 'GP',
+    alpha3Code: 'GLP',
+    numericCode: '312'
+  },
+  {
+    name: 'Grenada',
+    alpha2Code: 'GD',
+    alpha3Code: 'GRD',
+    numericCode: '308'
+  },
+  {
+    name: 'Guatemala',
+    alpha2Code: 'GT',
+    alpha3Code: 'GTM',
+    numericCode: '320'
+  },
+  {
+    name: 'Guinea',
+    alpha2Code: 'GN',
+    alpha3Code: 'GIN',
+    numericCode: '324'
+  },
+  {
+    name: 'Guinea-Bissau',
+    alpha2Code: 'GW',
+    alpha3Code: 'GNB',
+    numericCode: '624'
+  },
+  {
+    name: 'Guyana',
+    alpha2Code: 'GY',
+    alpha3Code: 'GUY',
+    numericCode: '328'
+  },
+  {
+    name: 'Haiti',
+    alpha2Code: 'HT',
+    alpha3Code: 'HTI',
+    numericCode: '332'
+  },
+  {
+    name: 'Honduras',
+    alpha2Code: 'HN',
+    alpha3Code: 'HND',
+    numericCode: '340'
+  },
+  {
+    name: 'Hong Kong',
+    alpha2Code: 'HK',
+    alpha3Code: 'HKG',
+    numericCode: '344'
+  },
+  {
+    name: 'Ungheria',
+    alpha2Code: 'HU',
+    alpha3Code: 'HUN',
+    numericCode: '348'
+  },
+  {
+    name: 'Islanda',
+    alpha2Code: 'IS',
+    alpha3Code: 'ISL',
+    numericCode: '352'
+  },
+  {
+    name: 'India',
+    alpha2Code: 'IN',
+    alpha3Code: 'IND',
+    numericCode: '356'
+  },
+  {
+    name: 'Indonesia',
+    alpha2Code: 'ID',
+    alpha3Code: 'IDN',
+    numericCode: '360'
+  },
+  {
+    name: 'Iran',
+    alpha2Code: 'IR',
+    alpha3Code: 'IRN',
+    numericCode: '364'
+  },
+  {
+    name: 'Iraq',
+    alpha2Code: 'IQ',
+    alpha3Code: 'IRQ',
+    numericCode: '368'
+  },
+  {
+    name: 'Irlanda',
+    alpha2Code: 'IE',
+    alpha3Code: 'IRL',
+    numericCode: '372'
+  },
+  {
+    name: 'Israel',
+    alpha2Code: 'IL',
+    alpha3Code: 'ISR',
+    numericCode: '376'
+  },
+  {
+    name: 'Italia',
+    alpha2Code: 'IT',
+    alpha3Code: 'ITA',
+    numericCode: '380'
+  },
+  {
+    name: 'Jamaica',
+    alpha2Code: 'JM',
+    alpha3Code: 'JAM',
+    numericCode: '388'
+  },
+  {
+    name: 'Giappone',
+    alpha2Code: 'JP',
+    alpha3Code: 'JPN',
+    numericCode: '392'
+  },
+  {
+    name: 'Jersey',
+    alpha2Code: 'JE',
+    alpha3Code: 'JEY',
+    numericCode: '832'
+  },
+  {
+    name: 'Jordan',
+    alpha2Code: 'JO',
+    alpha3Code: 'JOR',
+    numericCode: '400'
+  },
+  {
+    name: 'Kazakistan',
+    alpha2Code: 'KZ',
+    alpha3Code: 'KAZ',
+    numericCode: '398'
+  },
+  {
+    name: 'Kenya',
+    alpha2Code: 'KE',
+    alpha3Code: 'KEN',
+    numericCode: '404'
+  },
+  {
+    name: 'Kiribati',
+    alpha2Code: 'KI',
+    alpha3Code: 'KIR',
+    numericCode: '296'
+  },
+  {
+    name: 'Corea (Repubblica popolare democratica di)',
+    alpha2Code: 'KP',
+    alpha3Code: 'PRK',
+    numericCode: '408'
+  },
+  {
+    name: 'Corea (Repubblica di)  t',
+    alpha2Code: 'KR',
+    alpha3Code: 'KOR',
+    numericCode: '410'
+  },
+  {
+    name: 'Kuwait',
+    alpha2Code: 'KW',
+    alpha3Code: 'KWT',
+    numericCode: '414'
+  },
+  {
+    name: 'Kirghizistan',
+    alpha2Code: 'KG',
+    alpha3Code: 'KGZ',
+    numericCode: '417'
+  },
+  {
+    name: 'Laos',
+    alpha2Code: 'LA',
+    alpha3Code: 'LAO',
+    numericCode: '418'
+  },
+  {
+    name: 'Lettonia',
+    alpha2Code: 'LV',
+    alpha3Code: 'LVA',
+    numericCode: '428'
+  },
+  {
+    name: 'Libano',
+    alpha2Code: 'LB',
+    alpha3Code: 'LBN',
+    numericCode: '422'
+  },
+  {
+    name: 'Lesotho',
+    alpha2Code: 'LS',
+    alpha3Code: 'LSO',
+    numericCode: '426'
+  },
+  {
+    name: 'Liberia',
+    alpha2Code: 'LR',
+    alpha3Code: 'LBR',
+    numericCode: '430'
+  },
+  {
+    name: 'Libia',
+    alpha2Code: 'LY',
+    alpha3Code: 'LBY',
+    numericCode: '434'
+  },
+  {
+    name: 'Liechtenstein',
+    alpha2Code: 'LI',
+    alpha3Code: 'LIE',
+    numericCode: '438'
+  },
+  {
+    name: 'Lituania',
+    alpha2Code: 'LT',
+    alpha3Code: 'LTU',
+    numericCode: '440'
+  },
+  {
+    name: 'Lussemburgo',
+    alpha2Code: 'LU',
+    alpha3Code: 'LUX',
+    numericCode: '442'
+  },
+  {
+    name: 'Macao',
+    alpha2Code: 'MO',
+    alpha3Code: 'MAC',
+    numericCode: '446'
+  },
+  {
+    name: 'Madagascar',
+    alpha2Code: 'MG',
+    alpha3Code: 'MDG',
+    numericCode: '450'
+  },
+  {
+    name: 'Malawi',
+    alpha2Code: 'MW',
+    alpha3Code: 'MWI',
+    numericCode: '454'
+  },
+  {
+    name: 'Malaysia',
+    alpha2Code: 'MY',
+    alpha3Code: 'MYS',
+    numericCode: '458'
+  },
+  {
     name: 'Maldive',
     alpha2Code: 'MV',
     alpha3Code: 'MDV',
     numericCode: '462'
   },
-    {
-      name: 'Mali',
-      alpha2Code: 'ML',
-      alpha3Code: 'MLI',
-      numericCode: '466'
-    },
-    {
-      name: 'Malta',
-      alpha2Code: 'MT',
-      alpha3Code: 'MLT',
-      numericCode: '470'
-    },
-    {
-      name: 'Mauritania',
-      alpha2Code: 'MR',
-      alpha3Code: 'MRT',
-      numericCode: '478'
-    },
-    {
-      name: 'Mauritius',
-      alpha2Code: 'MU',
-      alpha3Code: 'MUS',
-      numericCode: '480'
-    },
-    {
-      name: 'Messico',
-      alpha2Code: 'MX',
-      alpha3Code: 'MEX',
-      numericCode: '484'
-    },
-    {
-      name: 'Moldova',
-      alpha2Code: 'MD',
-      alpha3Code: 'MDA',
-      numericCode: '498'
-    },
-    {
-      name: 'Monaco',
-      alpha2Code: 'MC',
-      alpha3Code: 'MCO',
-      numericCode: '492'
-    },
-    {
-      name: 'Mongolia',
-      alpha2Code: 'MN',
-      alpha3Code: 'MNG',
-      numericCode: '496'
-    },
-    {
-      name: 'Montenegro',
-      alpha2Code: 'ME',
-      alpha3Code: 'MNE',
-      numericCode: '499'
-    },
-    {
-      name: 'Morocco',
-      alpha2Code: 'MA',
-      alpha3Code: 'MAR',
-      numericCode: '504'
-    },
-    {
-      name: 'Mozambico',
-      alpha2Code: 'MZ',
-      alpha3Code: 'MOZ',
-      numericCode: '508'
-    },
-    {
-      name: 'Myanmar',
-      alpha2Code: 'MM',
-      alpha3Code: 'MMR',
-      numericCode: '104'
-    },
-    {
-      name: 'Namibia',
-      alpha2Code: 'NA',
-      alpha3Code: 'NAM',
-      numericCode: '516'
-    },
-    {
-      name: 'Nauru',
-      alpha2Code: 'NR',
-      alpha3Code: 'NRU',
-      numericCode: '520'
-    },
-    {
-      name: 'Nepal',
-      alpha2Code: 'NP',
-      alpha3Code: 'NPL',
-      numericCode: '524'
-    },
-    {
-      name: 'Paesi Bassi',
-      alpha2Code: 'NL',
-      alpha3Code: 'NLD',
-      numericCode: '528'
-    },
-    {
-      name: 'Nuova Caledonia',
-      alpha2Code: 'NC',
-      alpha3Code: 'NCL',
-      numericCode: '540'
-    },
-    {
-      name: 'Nuova Zelanda',
-      alpha2Code: 'NZ',
-      alpha3Code: 'NZL',
-      numericCode: '554'
-    },
-    {
-      name: 'Nicaragua',
-      alpha2Code: 'NI',
-      alpha3Code: 'NIC',
-      numericCode: '558'
-    },
-    {
-      name: 'Niger',
-      alpha2Code: 'NE',
-      alpha3Code: 'NER',
-      numericCode: '562'
-    },
-    {
-      name: 'Nigeria',
-      alpha2Code: 'NG',
-      alpha3Code: 'NGA',
-      numericCode: '566'
-    },
-    {
-      name: 'Norvegia',
-      alpha2Code: 'NO',
-      alpha3Code: 'NOR',
-      numericCode: '578'
-    },
-    {
-      name: 'Oman',
-      alpha2Code: 'OM',
-      alpha3Code: 'OMN',
-      numericCode: '512'
-    },
-    {
-      name: 'Pakistan',
-      alpha2Code: 'PK',
-      alpha3Code: 'PAK',
-      numericCode: '586'
-    },
-    {
-      name: 'Palau',
-      alpha2Code: 'PW',
-      alpha3Code: 'PLW',
-      numericCode: '585'
-    },
-    {
-      name: 'Palestina',
-      alpha2Code: 'PS',
-      alpha3Code: 'PSE',
-      numericCode: '275'
-    },
-    {
-      name: 'Panama',
-      alpha2Code: 'PA',
-      alpha3Code: 'PAN',
-      numericCode: '591'
-    },
-    {
-      name: 'Papua Nuova Guinea',
-      alpha2Code: 'PG',
-      alpha3Code: 'PNG',
-      numericCode: '598'
-    },
-    {
-      name: 'Paraguay',
-      alpha2Code: 'PY',
-      alpha3Code: 'PRY',
-      numericCode: '600'
-    },
-    {
-      name: 'Perù',
-      alpha2Code: 'PE',
-      alpha3Code: 'PER',
-      numericCode: '604'
-    },
-    {
-      name: 'Filippine',
-      alpha2Code: 'PH',
-      alpha3Code: 'PHL',
-      numericCode: '608'
-    },
-    {
-      name: 'Polonia',
-      alpha2Code: 'PL',
-      alpha3Code: 'POL',
-      numericCode: '616'
-    },
-    {
-      name: 'Portogallo',
-      alpha2Code: 'PT',
-      alpha3Code: 'PRT',
-      numericCode: '620'
-    },
-    {
-      name: 'Puerto Rico',
-      alpha2Code: 'PR',
-      alpha3Code: 'PRI',
-      numericCode: '630'
-    },
-    {
-      name: 'Qatar',
-      alpha2Code: 'QA',
-      alpha3Code: 'QAT',
-      numericCode: '634'
-    },
-    {
-      name: 'Repubblica della Macedonia del Nord',
-      alpha2Code: 'MK',
-      alpha3Code: 'MKD',
-      numericCode: '807'
-    },
-    {
-      name: 'Romania',
-      alpha2Code: 'RO',
-      alpha3Code: 'ROU',
-      numericCode: '642'
-    },
-    {
-      name: 'Federazione Russa (la)',
-      alpha2Code: 'RU',
-      alpha3Code: 'RUS',
-      numericCode: '643'
-    }, {
+  {
+    name: 'Mali',
+    alpha2Code: 'ML',
+    alpha3Code: 'MLI',
+    numericCode: '466'
+  },
+  {
+    name: 'Malta',
+    alpha2Code: 'MT',
+    alpha3Code: 'MLT',
+    numericCode: '470'
+  },
+  {
+    name: 'Mauritania',
+    alpha2Code: 'MR',
+    alpha3Code: 'MRT',
+    numericCode: '478'
+  },
+  {
+    name: 'Mauritius',
+    alpha2Code: 'MU',
+    alpha3Code: 'MUS',
+    numericCode: '480'
+  },
+  {
+    name: 'Messico',
+    alpha2Code: 'MX',
+    alpha3Code: 'MEX',
+    numericCode: '484'
+  },
+  {
+    name: 'Moldova',
+    alpha2Code: 'MD',
+    alpha3Code: 'MDA',
+    numericCode: '498'
+  },
+  {
+    name: 'Monaco',
+    alpha2Code: 'MC',
+    alpha3Code: 'MCO',
+    numericCode: '492'
+  },
+  {
+    name: 'Mongolia',
+    alpha2Code: 'MN',
+    alpha3Code: 'MNG',
+    numericCode: '496'
+  },
+  {
+    name: 'Montenegro',
+    alpha2Code: 'ME',
+    alpha3Code: 'MNE',
+    numericCode: '499'
+  },
+  {
+    name: 'Morocco',
+    alpha2Code: 'MA',
+    alpha3Code: 'MAR',
+    numericCode: '504'
+  },
+  {
+    name: 'Mozambico',
+    alpha2Code: 'MZ',
+    alpha3Code: 'MOZ',
+    numericCode: '508'
+  },
+  {
+    name: 'Myanmar',
+    alpha2Code: 'MM',
+    alpha3Code: 'MMR',
+    numericCode: '104'
+  },
+  {
+    name: 'Namibia',
+    alpha2Code: 'NA',
+    alpha3Code: 'NAM',
+    numericCode: '516'
+  },
+  {
+    name: 'Nauru',
+    alpha2Code: 'NR',
+    alpha3Code: 'NRU',
+    numericCode: '520'
+  },
+  {
+    name: 'Nepal',
+    alpha2Code: 'NP',
+    alpha3Code: 'NPL',
+    numericCode: '524'
+  },
+  {
+    name: 'Paesi Bassi',
+    alpha2Code: 'NL',
+    alpha3Code: 'NLD',
+    numericCode: '528'
+  },
+  {
+    name: 'Nuova Caledonia',
+    alpha2Code: 'NC',
+    alpha3Code: 'NCL',
+    numericCode: '540'
+  },
+  {
+    name: 'Nuova Zelanda',
+    alpha2Code: 'NZ',
+    alpha3Code: 'NZL',
+    numericCode: '554'
+  },
+  {
+    name: 'Nicaragua',
+    alpha2Code: 'NI',
+    alpha3Code: 'NIC',
+    numericCode: '558'
+  },
+  {
+    name: 'Niger',
+    alpha2Code: 'NE',
+    alpha3Code: 'NER',
+    numericCode: '562'
+  },
+  {
+    name: 'Nigeria',
+    alpha2Code: 'NG',
+    alpha3Code: 'NGA',
+    numericCode: '566'
+  },
+  {
+    name: 'Norvegia',
+    alpha2Code: 'NO',
+    alpha3Code: 'NOR',
+    numericCode: '578'
+  },
+  {
+    name: 'Oman',
+    alpha2Code: 'OM',
+    alpha3Code: 'OMN',
+    numericCode: '512'
+  },
+  {
+    name: 'Pakistan',
+    alpha2Code: 'PK',
+    alpha3Code: 'PAK',
+    numericCode: '586'
+  },
+  {
+    name: 'Palau',
+    alpha2Code: 'PW',
+    alpha3Code: 'PLW',
+    numericCode: '585'
+  },
+  {
+    name: 'Palestina',
+    alpha2Code: 'PS',
+    alpha3Code: 'PSE',
+    numericCode: '275'
+  },
+  {
+    name: 'Panama',
+    alpha2Code: 'PA',
+    alpha3Code: 'PAN',
+    numericCode: '591'
+  },
+  {
+    name: 'Papua Nuova Guinea',
+    alpha2Code: 'PG',
+    alpha3Code: 'PNG',
+    numericCode: '598'
+  },
+  {
+    name: 'Paraguay',
+    alpha2Code: 'PY',
+    alpha3Code: 'PRY',
+    numericCode: '600'
+  },
+  {
+    name: 'Perù',
+    alpha2Code: 'PE',
+    alpha3Code: 'PER',
+    numericCode: '604'
+  },
+  {
+    name: 'Filippine',
+    alpha2Code: 'PH',
+    alpha3Code: 'PHL',
+    numericCode: '608'
+  },
+  {
+    name: 'Polonia',
+    alpha2Code: 'PL',
+    alpha3Code: 'POL',
+    numericCode: '616'
+  },
+  {
+    name: 'Portogallo',
+    alpha2Code: 'PT',
+    alpha3Code: 'PRT',
+    numericCode: '620'
+  },
+  {
+    name: 'Puerto Rico',
+    alpha2Code: 'PR',
+    alpha3Code: 'PRI',
+    numericCode: '630'
+  },
+  {
+    name: 'Qatar',
+    alpha2Code: 'QA',
+    alpha3Code: 'QAT',
+    numericCode: '634'
+  },
+  {
+    name: 'Repubblica della Macedonia del Nord',
+    alpha2Code: 'MK',
+    alpha3Code: 'MKD',
+    numericCode: '807'
+  },
+  {
+    name: 'Romania',
+    alpha2Code: 'RO',
+    alpha3Code: 'ROU',
+    numericCode: '642'
+  },
+  {
+    name: 'Federazione Russa (la)',
+    alpha2Code: 'RU',
+    alpha3Code: 'RUS',
+    numericCode: '643'
+  },
+  {
     name: 'Ruanda',
     alpha2Code: 'RW',
     alpha3Code: 'RWA',
     numericCode: '646'
   },
-    {
-      name: 'Saint Kitts e Nevis',
-      alpha2Code: 'KN',
-      alpha3Code: 'KNA',
-      numericCode: '659'
-    },
-    {
-      name: 'Santa Lucia',
-      alpha2Code: 'LC',
-      alpha3Code: 'LCA',
-      numericCode: '662'
-    },
-    {
-      name: 'Saint Vincent e Grenadine',
-      alpha2Code: 'VC',
-      alpha3Code: 'VCT',
-      numericCode: '670'
-    },
-    {
-      name: 'Samoa',
-      alpha2Code: 'WS',
-      alpha3Code: 'WSM',
-      numericCode: '882'
-    },
-    {
-      name: 'San Marino',
-      alpha2Code: 'SM',
-      alpha3Code: 'SMR',
-      numericCode: '674'
-    },
-    {
-      name: 'Sao Tome e Principe',
-      alpha2Code: 'ST',
-      alpha3Code: 'STP',
-      numericCode: '678'
-    },
-    {
-      name: 'Arabia Saudita',
-      alpha2Code: 'SA',
-      alpha3Code: 'SAU',
-      numericCode: '682'
-    },
-    {
-      name: 'Senegal',
-      alpha2Code: 'SN',
-      alpha3Code: 'SEN',
-      numericCode: '686'
-    },
-    {
-      name: 'Serbia',
-      alpha2Code: 'RS',
-      alpha3Code: 'SRB',
-      numericCode: '688'
-    },
-    {
-      name: 'Seychelles',
-      alpha2Code: 'SC',
-      alpha3Code: 'SYC',
-      numericCode: '690'
-    },
-    {
-      name: 'Sierra Leone',
-      alpha2Code: 'SL',
-      alpha3Code: 'SLE',
-      numericCode: '694'
-    },
-    {
-      name: 'Singapore',
-      alpha2Code: 'SG',
-      alpha3Code: 'SGP',
-      numericCode: '702'
-    },
-    {
-      name: 'Slovacchia',
-      alpha2Code: 'SK',
-      alpha3Code: 'SVK',
-      numericCode: '703'
-    },
-    {
-      name: 'Slovenia',
-      alpha2Code: 'SI',
-      alpha3Code: 'SVN',
-      numericCode: '705'
-    },
-    {
-      name: 'Isole Salomone',
-      alpha2Code: 'SB',
-      alpha3Code: 'SLB',
-      numericCode: '090'
-    },
-    {
-      name: 'Somalia',
-      alpha2Code: 'SO',
-      alpha3Code: 'SOM',
-      numericCode: '706'
-    },
-    {
-      name: 'Sud Africa',
-      alpha2Code: 'ZA',
-      alpha3Code: 'ZAF',
-      numericCode: '710'
-    },
-    {
-      name: 'Sud Sudan',
-      alpha2Code: 'SS',
-      alpha3Code: 'SSD',
-      numericCode: '728'
-    },
-    {
-      name: 'Spagna',
-      alpha2Code: 'ES',
-      alpha3Code: 'ESP',
-      numericCode: '724'
-    },
-    {
-      name: 'Sri Lanka',
-      alpha2Code: 'LK',
-      alpha3Code: 'LKA',
-      numericCode: '144'
-    },
-    {
-      name: 'Sudan',
-      alpha2Code: 'SD',
-      alpha3Code: 'SDN',
-      numericCode: '729'
-    },
-    {
-      name: 'Suriname',
-      alpha2Code: 'SR',
-      alpha3Code: 'SUR',
-      numericCode: '740'
-    },
-    {
-      name: 'Svezia',
-      alpha2Code: 'SE',
-      alpha3Code: 'SWE',
-      numericCode: '752'
-    },
-    {
-      name: 'Svizzera',
-      alpha2Code: 'CH',
-      alpha3Code: 'CHE',
-      numericCode: '756'
-    },
-    {
-      name: 'Repubblica araba siriana',
-      alpha2Code: 'SY',
-      alpha3Code: 'SYR',
-      numericCode: '760'
-    },
-    {
-      name: 'Taiwan',
-      alpha2Code: 'TW',
-      alpha3Code: 'TWN',
-      numericCode: '158'
-    },
-    {
-      name: 'Tagikistan',
-      alpha2Code: 'TJ',
-      alpha3Code: 'TJK',
-      numericCode: '762'
-    },
-    {
-      name: 'Tanzania',
-      alpha2Code: 'TZ',
-      alpha3Code: 'TZA',
-      numericCode: '834'
-    },
-    {
-      name: 'Thailandia',
-      alpha2Code: 'TH',
-      alpha3Code: 'THA',
-      numericCode: '764'
-    },
-    {
-      name: 'Timor-Leste',
-      alpha2Code: 'TL',
-      alpha3Code: 'TLS',
-      numericCode: '626'
-    },
-    {
-      name: 'Togo',
-      alpha2Code: 'TG',
-      alpha3Code: 'TGO',
-      numericCode: '768'
-    },
-    {
-      name: 'Tonga',
-      alpha2Code: 'TO',
-      alpha3Code: 'TON',
-      numericCode: '776'
-    },
-    {
-      name: 'Trinidad e Tobago',
-      alpha2Code: 'TT',
-      alpha3Code: 'TTO',
-      numericCode: '780'
-    },
-    {
-      name: 'Tunisia',
-      alpha2Code: 'TN',
-      alpha3Code: 'TUN',
-      numericCode: '788'
-    },
-    {
-      name: 'Turchia',
-      alpha2Code: 'TR',
-      alpha3Code: 'TUR',
-      numericCode: '792'
-    },
-    {
-      name: 'Turkmenistan',
-      alpha2Code: 'TM',
-      alpha3Code: 'TKM',
-      numericCode: '795'
-    },
-    {
-      name: 'Tuvalu',
-      alpha2Code: 'TV',
-      alpha3Code: 'TUV',
-      numericCode: '798'
-    },
-    {
-      name: 'Uganda',
-      alpha2Code: 'UG',
-      alpha3Code: 'UGA',
-      numericCode: '800'
-    },
-    {
-      name: 'Ucraina',
-      alpha2Code: 'UA',
-      alpha3Code: 'UKR',
-      numericCode: '804'
-    }, {
+  {
+    name: 'Saint Kitts e Nevis',
+    alpha2Code: 'KN',
+    alpha3Code: 'KNA',
+    numericCode: '659'
+  },
+  {
+    name: 'Santa Lucia',
+    alpha2Code: 'LC',
+    alpha3Code: 'LCA',
+    numericCode: '662'
+  },
+  {
+    name: 'Saint Vincent e Grenadine',
+    alpha2Code: 'VC',
+    alpha3Code: 'VCT',
+    numericCode: '670'
+  },
+  {
+    name: 'Samoa',
+    alpha2Code: 'WS',
+    alpha3Code: 'WSM',
+    numericCode: '882'
+  },
+  {
+    name: 'San Marino',
+    alpha2Code: 'SM',
+    alpha3Code: 'SMR',
+    numericCode: '674'
+  },
+  {
+    name: 'Sao Tome e Principe',
+    alpha2Code: 'ST',
+    alpha3Code: 'STP',
+    numericCode: '678'
+  },
+  {
+    name: 'Arabia Saudita',
+    alpha2Code: 'SA',
+    alpha3Code: 'SAU',
+    numericCode: '682'
+  },
+  {
+    name: 'Senegal',
+    alpha2Code: 'SN',
+    alpha3Code: 'SEN',
+    numericCode: '686'
+  },
+  {
+    name: 'Serbia',
+    alpha2Code: 'RS',
+    alpha3Code: 'SRB',
+    numericCode: '688'
+  },
+  {
+    name: 'Seychelles',
+    alpha2Code: 'SC',
+    alpha3Code: 'SYC',
+    numericCode: '690'
+  },
+  {
+    name: 'Sierra Leone',
+    alpha2Code: 'SL',
+    alpha3Code: 'SLE',
+    numericCode: '694'
+  },
+  {
+    name: 'Singapore',
+    alpha2Code: 'SG',
+    alpha3Code: 'SGP',
+    numericCode: '702'
+  },
+  {
+    name: 'Slovacchia',
+    alpha2Code: 'SK',
+    alpha3Code: 'SVK',
+    numericCode: '703'
+  },
+  {
+    name: 'Slovenia',
+    alpha2Code: 'SI',
+    alpha3Code: 'SVN',
+    numericCode: '705'
+  },
+  {
+    name: 'Isole Salomone',
+    alpha2Code: 'SB',
+    alpha3Code: 'SLB',
+    numericCode: '090'
+  },
+  {
+    name: 'Somalia',
+    alpha2Code: 'SO',
+    alpha3Code: 'SOM',
+    numericCode: '706'
+  },
+  {
+    name: 'Sud Africa',
+    alpha2Code: 'ZA',
+    alpha3Code: 'ZAF',
+    numericCode: '710'
+  },
+  {
+    name: 'Sud Sudan',
+    alpha2Code: 'SS',
+    alpha3Code: 'SSD',
+    numericCode: '728'
+  },
+  {
+    name: 'Spagna',
+    alpha2Code: 'ES',
+    alpha3Code: 'ESP',
+    numericCode: '724'
+  },
+  {
+    name: 'Sri Lanka',
+    alpha2Code: 'LK',
+    alpha3Code: 'LKA',
+    numericCode: '144'
+  },
+  {
+    name: 'Sudan',
+    alpha2Code: 'SD',
+    alpha3Code: 'SDN',
+    numericCode: '729'
+  },
+  {
+    name: 'Suriname',
+    alpha2Code: 'SR',
+    alpha3Code: 'SUR',
+    numericCode: '740'
+  },
+  {
+    name: 'Svezia',
+    alpha2Code: 'SE',
+    alpha3Code: 'SWE',
+    numericCode: '752'
+  },
+  {
+    name: 'Svizzera',
+    alpha2Code: 'CH',
+    alpha3Code: 'CHE',
+    numericCode: '756'
+  },
+  {
+    name: 'Repubblica araba siriana',
+    alpha2Code: 'SY',
+    alpha3Code: 'SYR',
+    numericCode: '760'
+  },
+  {
+    name: 'Taiwan',
+    alpha2Code: 'TW',
+    alpha3Code: 'TWN',
+    numericCode: '158'
+  },
+  {
+    name: 'Tagikistan',
+    alpha2Code: 'TJ',
+    alpha3Code: 'TJK',
+    numericCode: '762'
+  },
+  {
+    name: 'Tanzania',
+    alpha2Code: 'TZ',
+    alpha3Code: 'TZA',
+    numericCode: '834'
+  },
+  {
+    name: 'Thailandia',
+    alpha2Code: 'TH',
+    alpha3Code: 'THA',
+    numericCode: '764'
+  },
+  {
+    name: 'Timor-Leste',
+    alpha2Code: 'TL',
+    alpha3Code: 'TLS',
+    numericCode: '626'
+  },
+  {
+    name: 'Togo',
+    alpha2Code: 'TG',
+    alpha3Code: 'TGO',
+    numericCode: '768'
+  },
+  {
+    name: 'Tonga',
+    alpha2Code: 'TO',
+    alpha3Code: 'TON',
+    numericCode: '776'
+  },
+  {
+    name: 'Trinidad e Tobago',
+    alpha2Code: 'TT',
+    alpha3Code: 'TTO',
+    numericCode: '780'
+  },
+  {
+    name: 'Tunisia',
+    alpha2Code: 'TN',
+    alpha3Code: 'TUN',
+    numericCode: '788'
+  },
+  {
+    name: 'Turchia',
+    alpha2Code: 'TR',
+    alpha3Code: 'TUR',
+    numericCode: '792'
+  },
+  {
+    name: 'Turkmenistan',
+    alpha2Code: 'TM',
+    alpha3Code: 'TKM',
+    numericCode: '795'
+  },
+  {
+    name: 'Tuvalu',
+    alpha2Code: 'TV',
+    alpha3Code: 'TUV',
+    numericCode: '798'
+  },
+  {
+    name: 'Uganda',
+    alpha2Code: 'UG',
+    alpha3Code: 'UGA',
+    numericCode: '800'
+  },
+  {
+    name: 'Ucraina',
+    alpha2Code: 'UA',
+    alpha3Code: 'UKR',
+    numericCode: '804'
+  },
+  {
     name: 'Emirati Arabi Uniti',
     alpha2Code: 'AE',
     alpha3Code: 'ARE',
     numericCode: '784'
   },
-    {
-      name: 'Regno Unito',
-      alpha2Code: 'GB',
-      alpha3Code: 'GBR',
-      numericCode: '826'
-    },
-    {
-      name: 'Stati Uniti d\'America',
-      alpha2Code: 'USA',
-      alpha3Code: 'USA',
-      numericCode: '840'
-    },
-    {
-      name: 'Uruguay',
-      alpha2Code: 'UY',
-      alpha3Code: 'URY',
-      numericCode: '858'
-    },
-    {
-      name: 'Uzbekistan',
-      alpha2Code: 'UZ',
-      alpha3Code: 'UZB',
-      numericCode: '860'
-    },
-    {
-      name: 'Vanuatu',
-      alpha2Code: 'VU',
-      alpha3Code: 'VUT',
-      numericCode: '548'
-    },
-    {
-      name: 'Venezuela',
-      alpha2Code: 'VE',
-      alpha3Code: 'VEN',
-      numericCode: '862'
-    },
-    {
-      name: 'Vietnam',
-      alpha2Code: 'VN',
-      alpha3Code: 'VNM',
-      numericCode: '704'
-    },
-    {
-      name: 'Yemen',
-      alpha2Code: 'YE',
-      alpha3Code: 'YEM',
-      numericCode: '887'
-    },
-    {
-      name: 'Zambia',
-      alpha2Code: 'ZM',
-      alpha3Code: 'ZMB',
-      numericCode: '894'
-    },
-    {
-      name: 'Zimbabwe',
-      alpha2Code: 'ZW',
-      alpha3Code: 'ZWE',
-      numericCode: '716'
-    }
-  ]
-;
+  {
+    name: 'Regno Unito',
+    alpha2Code: 'GB',
+    alpha3Code: 'GBR',
+    numericCode: '826'
+  },
+  {
+    name: "Stati Uniti d'America",
+    alpha2Code: 'US',
+    alpha3Code: 'USA',
+    numericCode: '840'
+  },
+  {
+    name: 'Uruguay',
+    alpha2Code: 'UY',
+    alpha3Code: 'URY',
+    numericCode: '858'
+  },
+  {
+    name: 'Uzbekistan',
+    alpha2Code: 'UZ',
+    alpha3Code: 'UZB',
+    numericCode: '860'
+  },
+  {
+    name: 'Vanuatu',
+    alpha2Code: 'VU',
+    alpha3Code: 'VUT',
+    numericCode: '548'
+  },
+  {
+    name: 'Venezuela',
+    alpha2Code: 'VE',
+    alpha3Code: 'VEN',
+    numericCode: '862'
+  },
+  {
+    name: 'Vietnam',
+    alpha2Code: 'VN',
+    alpha3Code: 'VNM',
+    numericCode: '704'
+  },
+  {
+    name: 'Yemen',
+    alpha2Code: 'YE',
+    alpha3Code: 'YEM',
+    numericCode: '887'
+  },
+  {
+    name: 'Zambia',
+    alpha2Code: 'ZM',
+    alpha3Code: 'ZMB',
+    numericCode: '894'
+  },
+  {
+    name: 'Zimbabwe',
+    alpha2Code: 'ZW',
+    alpha3Code: 'ZWE',
+    numericCode: '716'
+  }
+];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,14 +1,16 @@
 import { NgModule } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
+import { ReactiveFormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FlexLayoutModule } from '@angular/flex-layout';
+
+import { MatSelectCountryModule } from '@angular-material-extensions/select-country';
+import { MarkdownModule } from 'ngx-markdown';
+import { Angulartics2Module } from 'angulartics2';
+
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MatSelectCountryModule } from '@angular-material-extensions/select-country';
-import { HttpClientModule } from '@angular/common/http';
-import { MarkdownModule } from 'ngx-markdown';
-import { FlexLayoutModule } from '@angular/flex-layout';
-import { BrowserModule } from '@angular/platform-browser';
-import { Angulartics2Module } from 'angulartics2';
-import { ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [AppComponent],

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -1,16 +1,16 @@
 import { NgModule } from '@angular/core';
 import { ServerModule } from '@angular/platform-server';
+import { FlexLayoutServerModule } from '@angular/flex-layout/server';
 
 import { AppModule } from './app.module';
 import { AppComponent } from './app.component';
-import {FlexLayoutServerModule} from '@angular/flex-layout/server';
 
 @NgModule({
   imports: [
     AppModule,
     FlexLayoutServerModule,
     ServerModule
-],
+  ],
   bootstrap: [AppComponent],
 })
 export class AppServerModule {}


### PR DESCRIPTION
ES:
`alpha2Code: 'POR'`

FR:
```
alpha2Code: 'PAR',
alpha2Code: 'EST',
alpha2Code: 'MON',
alpha2Code: 'NON',
alpha2Code: 'OUI',
```

IT:
`alpha2Code: 'USA',`